### PR TITLE
Remove some inconsistencies in the cheatsheet

### DIFF
--- a/cheatsheet/raylib_audio.c
+++ b/cheatsheet/raylib_audio.c
@@ -7,7 +7,6 @@
 
     // Wave/Sound loading/unloading functions
     Wave LoadWave(const char *fileName);                                            // Load wave data from file
-    Wave LoadWaveEx(void *data, int sampleCount, int sampleRate, int sampleSize, int channels); // Load wave data from raw array data
     Sound LoadSound(const char *fileName);                                          // Load sound from file
     Sound LoadSoundFromWave(Wave wave);                                             // Load sound from wave data
     void UpdateSound(Sound sound, const void *data, int samplesCount);              // Update sound buffer with new data
@@ -51,7 +50,7 @@
     AudioStream InitAudioStream(unsigned int sampleRate, unsigned int sampleSize, unsigned int channels); // Init audio stream (to stream raw audio pcm data)
     void UpdateAudioStream(AudioStream stream, const void *data, int samplesCount); // Update audio stream buffers with data
     void CloseAudioStream(AudioStream stream);                                      // Close audio stream and free memory
-    bool IsAudioBufferProcessed(AudioStream stream);                                // Check if any audio stream buffers requires refill
+    bool IsAudioStreamProcessed(AudioStream stream);                                // Check if any audio stream buffers requires refill
     void PlayAudioStream(AudioStream stream);                                       // Play audio stream
     void PauseAudioStream(AudioStream stream);                                      // Pause audio stream
     void ResumeAudioStream(AudioStream stream);                                     // Resume audio stream
@@ -59,4 +58,4 @@
     void StopAudioStream(AudioStream stream);                                       // Stop audio stream
     void SetAudioStreamVolume(AudioStream stream, float volume);                    // Set volume for audio stream (1.0 is max level)
     void SetAudioStreamPitch(AudioStream stream, float pitch);                      // Set pitch for audio stream (1.0 is base level)
-    
+    void SetAudioStreamBufferSizeDefault(int size);                                 // Default size for new audio streams

--- a/cheatsheet/raylib_core.c
+++ b/cheatsheet/raylib_core.c
@@ -55,7 +55,7 @@
     Matrix GetCameraMatrix(Camera camera);                                  // Returns camera transform matrix (view matrix)
     Matrix GetCameraMatrix2D(Camera2D camera);                              // Returns camera 2d transform matrix
     Vector2 GetWorldToScreen(Vector3 position, Camera camera);              // Returns the screen space position for a 3d world space position
-    Vector2 GetWorldToScreenEx(Vector3 position, Camera camera,int width, int height); // Returns size position for a 3d world space position
+    Vector2 GetWorldToScreenEx(Vector3 position, Camera camera, int width, int height); // Returns size position for a 3d world space position
     Vector2 GetWorldToScreen2D(Vector2 position, Camera2D camera);          // Returns the screen space position for a 2d camera world space position
     Vector2 GetScreenToWorld2D(Vector2 position, Camera2D camera);          // Returns the world space position for a 2d camera screen space position
                 
@@ -84,8 +84,8 @@
     int GetRandomValue(int min, int max);                                   // Returns a random value between min and max (both included)
                 
     // Files management functions
-    unsigned char *LoadFileData(const char *fileName, int *bytesRead);      // Load file data as byte array (read)
-    void SaveFileData(const char *fileName, void *data, int bytesToWrite);  // Save data to file from byte array (write)
+    unsigned char *LoadFileData(const char *fileName, unsigned int *bytesRead);     // Load file data as byte array (read)
+    void SaveFileData(const char *fileName, void *data, unsigned int bytesToWrite); // Save data to file from byte array (write)
     char *LoadFileText(const char *fileName);                               // Load text data from file (read), returns a '\0' terminated string
     void SaveFileText(const char *fileName, char *text);                    // Save text data to file (write), string must be '\0' terminated    
     bool FileExists(const char *fileName);                                  // Check if file exists
@@ -109,8 +109,8 @@
     unsigned char *DecompressData(unsigned char *compData, int compDataLength, int *dataLength);  // Decompress data (DEFLATE algorythm)
     
     // Persistent storage management
-    int LoadStorageValue(int position);                                     // Load integer value from storage file (from defined position)
-    void SaveStorageValue(int position, int value);                         // Save integer value to storage file (to defined position)
+    void SaveStorageValue(unsigned int position, int value);                // Save integer value to storage file (to defined position)
+    int LoadStorageValue(unsigned int position);                            // Load integer value from storage file (from defined position)
     
     void OpenURL(const char *url);                                          // Open URL with default system browser (if available)
 

--- a/cheatsheet/raylib_shaders.c
+++ b/cheatsheet/raylib_shaders.c
@@ -1,6 +1,5 @@
 
     // Shader loading/unloading functions
-    char *LoadText(const char *fileName);                                                               // Load chars array from text file
     Shader LoadShader(const char *vsFileName, const char *fsFileName);                                  // Load shader from files and bind default locations
     Shader LoadShaderCode(char *vsCode, char *fsCode);                                                  // Load shader from code strings and bind default locations
     void UnloadShader(Shader shader);                                                                   // Unload shader from GPU memory (VRAM)


### PR DESCRIPTION
This addresses the differences between the cheatsheet and raylib.h at version 3.0.0, as discussed in issue #11.

Note that:
- `GenTexture*()` functions were left out.
- The PDF version wasn't updated. (How is it generated?)