### PR TITLE
Updated the links of raylib-lua and raylib-odin

### DIFF
--- a/index.html
+++ b/index.html
@@ -113,7 +113,7 @@
                         <a href="https://github.com/D3nX/raylib-ruby-ffi" target="_blank"><img class="icon" src="images/bindings/bind_ruby.png" title="raylib-ruby" alt="ruby raylib binding" width="84" height="84"/></a>
                         <a href="https://github.com/Rabios/raylua" target="_blank"><img class="icon" src="images/bindings/bind_lua.png" title="raylib-lua" alt="lua raylib binding" width="84" height="84"/></a>
                         <a href="https://github.com/deltaphc/raylib-rs" target="_blank"><img class="icon" src="images/bindings/bind_rust.png" title="raylib-rs" alt="rust raylib binding" width="84" height="84"/></a>
-                        <a href="https://github.com/kevinw/raylib-odin" target="_blank"><img class="icon" src="images/bindings/bind_odin.png" title="raylib-odin" alt="odin raylib binding" width="84" height="84"/></a>
+                        <a href="https://github.com/odin-lang/Odin/tree/master/vendor/raylib" target="_blank"><img class="icon" src="images/bindings/bind_odin.png" title="raylib-odin" alt="odin raylib binding" width="84" height="84"/></a>
                         <a href="https://github.com/raysan5/raylib/blob/master/BINDINGS.md" target="_blank"><img class="icon" src="images/bindings/bind_more.png" title="more..." alt="more raylib bindings" width="84" height="84"/></a>
                     </div>
                 </div>

--- a/index.html
+++ b/index.html
@@ -111,7 +111,7 @@
                         <a href="https://github.com/gen2brain/raylib-go" target="_blank"><img class="icon" src="images/bindings/bind_go.png" title="raylib-go" alt="go raylib binding" width="84" height="84"/></a>
                         <a href="https://github.com/overdev/raylib-py" target="_blank"><img class="icon" src="images/bindings/bind_python.png" title="raylib-py" alt="python raylib binding" width="84" height="84"/></a>
                         <a href="https://github.com/D3nX/raylib-ruby-ffi" target="_blank"><img class="icon" src="images/bindings/bind_ruby.png" title="raylib-ruby" alt="ruby raylib binding" width="84" height="84"/></a>
-                        <a href="https://github.com/raysan5/raylib-lua" target="_blank"><img class="icon" src="images/bindings/bind_lua.png" title="raylib-lua" alt="lua raylib binding" width="84" height="84"/></a>
+                        <a href="https://github.com/Rabios/raylua" target="_blank"><img class="icon" src="images/bindings/bind_lua.png" title="raylib-lua" alt="lua raylib binding" width="84" height="84"/></a>
                         <a href="https://github.com/deltaphc/raylib-rs" target="_blank"><img class="icon" src="images/bindings/bind_rust.png" title="raylib-rs" alt="rust raylib binding" width="84" height="84"/></a>
                         <a href="https://github.com/kevinw/raylib-odin" target="_blank"><img class="icon" src="images/bindings/bind_odin.png" title="raylib-odin" alt="odin raylib binding" width="84" height="84"/></a>
                         <a href="https://github.com/raysan5/raylib/blob/master/BINDINGS.md" target="_blank"><img class="icon" src="images/bindings/bind_more.png" title="more..." alt="more raylib bindings" width="84" height="84"/></a>


### PR DESCRIPTION
> Changed kevinw/raylib-odin to Odin/vendor/raylib

Because the "odin-lang/Odin/vendor/raylib" binding is official binding and is up to date.