### PR TITLE
fix mobile browser issue

### DIFF
--- a/common/banner.css
+++ b/common/banner.css
@@ -1,8 +1,10 @@
 .gamejam-2022-banner {
+  min-width: 880px;
   background-color: white;
   padding: 1em;
   display: flex;
   justify-content: center;
+  align-items: center;
   flex-direction: row;
 }
 


### PR DESCRIPTION
On mobile the site's body element is a small box in the top left corner so I had to add something to force the banner area to a min width otherwise it goes off the left edge.