### PR TITLE
Add "no arrow scroll" mode to code/loader.html

### DIFF
--- a/common/disable-arrow-scroll.js
+++ b/common/disable-arrow-scroll.js
@@ -1,0 +1,47 @@
+window.addEventListener("DOMContentLoaded", () => {
+  var clickedInCanvas = false;
+  var warning = document.createElement("div");
+  warning.innerHTML =
+    "Arrow key scrolling disabled.<br />Click outside canvas or press Escape to enable again.";
+  warning.style.padding = "1em";
+  warning.style.color = "white";
+  warning.style.backgroundColor = "red";
+  warning.style.position = "fixed";
+  warning.style.bottom = 0;
+  warning.style.left = 0;
+  warning.style.right = 0;
+  warning.style.textAlign = "center";
+  warning.id = "no-scroll-warning-20220323";
+  warning.style.display = "none";
+  warning.style.fontFamily =
+    "grixel_acme_7_wide_xtnd, Courier New, Verdana, Arial";
+  document.body.appendChild(warning);
+
+  function update() {
+    warning.style.display = clickedInCanvas ? "block" : "none";
+  }
+
+  window.addEventListener("click", (ev) => {
+    clickedInCanvas = ev.target.tagName.toUpperCase() == "CANVAS";
+    update();
+  });
+  window.addEventListener(
+    "keydown",
+    (ev) => {
+      if (clickedInCanvas) {
+        if (
+          ["Space", "ArrowUp", "ArrowDown", "ArrowLeft", "ArrowRight"].indexOf(
+            ev.code
+          ) > -1
+        ) {
+          ev.preventDefault();
+        }
+      }
+      if (ev.code == "Escape") {
+        clickedInCanvas = false;
+        update();
+      }
+    },
+    false
+  );
+});

--- a/examples/audio/loader.html
+++ b/examples/audio/loader.html
@@ -238,5 +238,8 @@
             ga('require', 'linkid', 'linkid.js');
             ga('send', 'pageview');
         </script>
+
+        <!-- prevent arrow keys fromscrolling the loaded game. -->
+        <script src="/common/disable-arrow-scroll.js"></script>     
     </body>
 </html>

--- a/examples/core/loader.html
+++ b/examples/core/loader.html
@@ -238,5 +238,46 @@
             ga('require', 'linkid', 'linkid.js');
             ga('send', 'pageview');
         </script>
+
+        <!-- prevent arrow keys fromscrolling the loaded game. -->
+        <script>
+          window.addEventListener('DOMContentLoaded', () => {
+            var clickedInCanvas = false;
+            var warning = document.createElement('div');
+            warning.innerHTML = 'Arrow key scrolling disabled. Click outside canvas or press Escape to enable again.';
+            warning.style.padding = '1em';
+            warning.style.color = 'white';
+            warning.style.backgroundColor = 'red';
+            warning.style.position = 'fixed';
+            warning.style.bottom = 0;
+            warning.style.left = 0;
+            warning.style.right = 0;
+            warning.style.textAlign = 'center';
+            warning.id = 'no-scroll-warning-20220323';
+            warning.style.display = 'none';
+            document.body.appendChild(warning);
+
+            function update() {
+              warning.style.display = clickedInCanvas ? 'block' : 'none';
+            }
+
+            window.addEventListener('click', (ev) => {
+              clickedInCanvas = ev.target.tagName.toUpperCase() == 'CANVAS';
+              update();
+            });
+            window.addEventListener("keydown", (ev) => {
+              if (clickedInCanvas) {
+                if (["Space", "ArrowUp", "ArrowDown", "ArrowLeft", "ArrowRight"].indexOf(ev.code) > -1) {
+                  ev.preventDefault();
+                }
+              } 
+              if (ev.code == 'Escape') {
+                clickedInCanvas = false;
+                update();
+              }
+            }, false);
+
+          });
+        </script>        
     </body>
 </html>

--- a/examples/core/loader.html
+++ b/examples/core/loader.html
@@ -240,44 +240,6 @@
         </script>
 
         <!-- prevent arrow keys fromscrolling the loaded game. -->
-        <script>
-          window.addEventListener('DOMContentLoaded', () => {
-            var clickedInCanvas = false;
-            var warning = document.createElement('div');
-            warning.innerHTML = 'Arrow key scrolling disabled. Click outside canvas or press Escape to enable again.';
-            warning.style.padding = '1em';
-            warning.style.color = 'white';
-            warning.style.backgroundColor = 'red';
-            warning.style.position = 'fixed';
-            warning.style.bottom = 0;
-            warning.style.left = 0;
-            warning.style.right = 0;
-            warning.style.textAlign = 'center';
-            warning.id = 'no-scroll-warning-20220323';
-            warning.style.display = 'none';
-            document.body.appendChild(warning);
-
-            function update() {
-              warning.style.display = clickedInCanvas ? 'block' : 'none';
-            }
-
-            window.addEventListener('click', (ev) => {
-              clickedInCanvas = ev.target.tagName.toUpperCase() == 'CANVAS';
-              update();
-            });
-            window.addEventListener("keydown", (ev) => {
-              if (clickedInCanvas) {
-                if (["Space", "ArrowUp", "ArrowDown", "ArrowLeft", "ArrowRight"].indexOf(ev.code) > -1) {
-                  ev.preventDefault();
-                }
-              } 
-              if (ev.code == 'Escape') {
-                clickedInCanvas = false;
-                update();
-              }
-            }, false);
-
-          });
-        </script>        
+        <script src="/common/disable-arrow-scroll.js"></script>        
     </body>
 </html>

--- a/examples/models/loader.html
+++ b/examples/models/loader.html
@@ -238,5 +238,8 @@
             ga('require', 'linkid', 'linkid.js');
             ga('send', 'pageview');
         </script>
+
+        <!-- prevent arrow keys fromscrolling the loaded game. -->
+        <script src="/common/disable-arrow-scroll.js"></script>     
     </body>
 </html>

--- a/examples/physics/loader.html
+++ b/examples/physics/loader.html
@@ -236,5 +236,8 @@
             ga('require', 'linkid', 'linkid.js');
             ga('send', 'pageview');
         </script>
+
+        <!-- prevent arrow keys fromscrolling the loaded game. -->
+        <script src="/common/disable-arrow-scroll.js"></script>     
     </body>
 </html>

--- a/examples/shaders/loader.html
+++ b/examples/shaders/loader.html
@@ -230,5 +230,8 @@
             ga('require', 'linkid', 'linkid.js');
             ga('send', 'pageview');
         </script>
+
+        <!-- prevent arrow keys fromscrolling the loaded game. -->
+        <script src="/common/disable-arrow-scroll.js"></script>             
     </body>
 </html>

--- a/examples/shapes/loader.html
+++ b/examples/shapes/loader.html
@@ -238,5 +238,8 @@
             ga('require', 'linkid', 'linkid.js');
             ga('send', 'pageview');
         </script>
+
+        <!-- prevent arrow keys fromscrolling the loaded game. -->
+        <script src="/common/disable-arrow-scroll.js"></script>             
     </body>
 </html>

--- a/examples/text/loader.html
+++ b/examples/text/loader.html
@@ -238,5 +238,8 @@
             ga('require', 'linkid', 'linkid.js');
             ga('send', 'pageview');
         </script>
+
+        <!-- prevent arrow keys fromscrolling the loaded game. -->
+        <script src="/common/disable-arrow-scroll.js"></script>     
     </body>
 </html>

--- a/examples/textures/loader.html
+++ b/examples/textures/loader.html
@@ -238,5 +238,8 @@
             ga('require', 'linkid', 'linkid.js');
             ga('send', 'pageview');
         </script>
+        
+        <!-- prevent arrow keys fromscrolling the loaded game. -->
+        <script src="/common/disable-arrow-scroll.js"></script>             
     </body>
 </html>


### PR DESCRIPTION
When the canvas is clicked a message appears at the bottom of the iframe that arrow scrolling is disabled and explains that you can click outside the canvas or press escape to enable arrow scrolling again.

When arrow scrolling is disabled pressing the down arrow, up arrow, or space bar will not cause the iframe to scroll. 

I only noticed one example in core that uses the down arrow so I only applied it there but it can be added to any page. It simply watches for clicks and reacts if a canvas is clicked, it doesn't care which canvas.

Preview:
![Screenshot from 2022-03-23 12-32-42](https://user-images.githubusercontent.com/42419558/159749668-5b28f189-8566-42f3-a1cb-0605fa316aa0.png)
