### PR TITLE
added cheatsheet generator

### DIFF
--- a/cheatsheet/cheatsheet.html
+++ b/cheatsheet/cheatsheet.html
@@ -56,6 +56,7 @@
          #audio pre code{border:10px solid; border-color:#d3b157; background-color:#e5d7ae; }
          #structs pre code{border:10px solid; border-color:#d2c9c6; background-color:#f8f8ff;}
          #colors pre code{border:10px solid; border-color:#c6d2c6; background-color:#e9f1f2;}
+         #math pre code{border:10px solid; border-color:#c170ff; background-color:#deb3ff; }
          #logo{width:128px; height:128px; float:left; position:relative; background-image:url(../common/img/raylib_logo.png);}
          #header{position:relative; height:110px; width: 1000px;}
          #title, #plinks, #version{position:relative; float:left; margin:0px; margin-left:10px; margin-top:10px;}
@@ -71,6 +72,7 @@
          #paudio{margin-bottom:-12px; margin-left:12px; color:#8c7539;}
          #pstructs{margin-bottom:-12px; margin-left:12px; color:#bcbccd;}
          #pcolors{margin-bottom:-12px; margin-left:12px; color:#bcbccd;}
+         #pmath{margin-bottom:-12px; margin-left:12px; color:#9d1cff;}
 
          #fullgroup{
              display: grid;
@@ -119,6 +121,10 @@
                  $('#structs pre code').text(data);
                  $('#structs pre code').each(function(i, e) {hljs.highlightBlock(e)});
              }, 'text');
+             $.get('raylib_math.c', function(data) {
+                 $('#math pre code').text(data);
+                 $('#math pre code').each(function(i, e) {hljs.highlightBlock(e)});
+             }, 'text');
          });
         </script>
     </head>
@@ -156,6 +162,8 @@
                     <div id="colors"><pre><code class="cpp"></code></pre></div>
                 </div>
             </div>
+            <p id="pmath">module: rmath</p>
+            <div id="math"><pre><code class="cpp"></code></pre></div>
             <div id="copyright">
                 <p>raylib quick reference card - Copyright (c) 2013-2022 Ramon Santamaria (<a href="https://www.twitter.com/raysan5">@raysan5</a>)</p>
             </div>

--- a/cheatsheet/generate_cheatsheet_code.py
+++ b/cheatsheet/generate_cheatsheet_code.py
@@ -1,0 +1,169 @@
+import os
+import sys
+import argparse
+from contextlib import contextmanager
+
+def parseColors(inp, outp, modules):
+    previous_line = ""
+    data = []
+    indicator = "CLITERAL(Color)"
+    for line in inp.readlines():
+        if indicator in line or indicator in previous_line:
+            data.append(previous_line.strip())
+        previous_line = line
+
+    for d in data:
+        print(f"    {d.replace('CLITERAL', '').replace('NOTE: ', '')}".rstrip(), file=outp)
+
+
+def parseStructs(inp, outp, modules):
+    struct_section_starters = ["Image", "Camera", "Wave", "VrDeviceInfo", "FilePathList"]
+    start_section = "// Structures Definition\n"
+    end_section = "// Enumerators Definition\n"
+    data = []
+    comment = []
+    for line in inp.readlines():
+        if line == start_section:
+            data = []
+            comment = []
+        elif line == end_section:
+            break
+        elif line.startswith("//--"):
+            pass
+        elif line.startswith("//"):
+            comment.append(line.strip())
+        elif line.strip().startswith("typedef struct"):
+            if line[len("typedef struct") + 1].isupper():
+                data.append((line.strip(" {\n"), comment))
+            comment = []
+        elif line.strip().startswith("typedef"):
+            comment = []  # ignore non structs, just like the current cheatsheet
+
+    for d in data:
+        struct = d[0].replace("CLITERAL", "").replace("typedef ", "") + ";"
+        for s in struct_section_starters:
+            if s in struct:
+                print(file=outp)
+        comments = ("\n" + (35 * " ")).join(d[1])
+        print(f"    {struct:30} {comments}", file=outp)
+
+
+def parseMathFile(inp, outp, modules):
+    tag = "RMAPI"
+    data = []
+    comments = []
+    for line in inp.readlines():
+        if line.startswith("// Module Functions Definition"):
+            data.append((line[len("// Module Functions Definition - "):-1],))
+        elif line.startswith("//------"):
+            pass
+        elif line.startswith("//"):
+            comments.append(line.strip("\n /"))
+        elif line.startswith(tag):
+            data.append((line[len(tag)+1:].strip(), comments))
+            comments = []
+
+    for d in data:
+        if len(d) == 2:
+            print(f"    {d[0]:75} {'//' if len(d[1]) > 0 else ''} {' '.join(d[1])}", file=outp)
+        elif len(d) == 1:
+            print(f"\n    // {d[0]}", file=outp)
+
+
+def parseFile(inp, outp, modules):
+    tag = "RLAPI"
+    data = []
+    current_module = ""
+    moduleHeader = "(Module: "
+    for line in inp.readlines():
+        if moduleHeader in line:
+            idx = line.index(moduleHeader) + len(moduleHeader)
+            idx_end = line.index(")", idx)
+            wasnt_in = False
+            if not (current_module in modules):
+                data = []
+                wasnt_in = True
+            current_module = line[idx:idx_end]
+            if not wasnt_in and not current_module in modules:
+                break
+        if current_module in modules:
+            if line.startswith("//"):
+                data.append(line.strip())
+            elif line.startswith("\n"):
+                data.append(line.strip())
+            elif line.startswith(tag):
+                data.append(line[len(tag):].strip())
+
+    # 3 and onwards to skip first module declaration
+    for d in data[3:-1]:
+        print(f"    {d}".rstrip(), file=outp)
+
+
+@contextmanager
+def fileorstd(filepath, data=''):
+    if isinstance(filepath, str):
+        fil = open(filepath, data)
+        try:
+            yield fil
+        finally:
+            fil.close()
+    else:  # is stdin or stdout
+        yield filepath
+
+
+def performModule(module, mathin, libin, outp):
+    with fileorstd(mathin if module == ["math"] else libin, "r") as sin, \
+         fileorstd(outp, "w+") as sout:
+        fn = parseFile
+        if module == ["math"]:
+            fn = parseMathFile
+        if module == ["structs"]:
+            fn = parseStructs
+        if module == ["colors"]:
+            fn = parseColors
+        fn(sin, sout, module)
+
+
+def main():
+    all_modules = ["core", "rgestures", "rcamera", "shapes", "textures", "text", "models", "audio", "math"]
+    modules = {
+        "core": ["core", "rgestures", "rcamera"],
+        "shapes": ["shapes"],
+        "textures": ["textures"],
+        "text": ["text"],
+        "models": ["models"],
+        "audio": ["audio"],
+        "math": ["math"],
+        "structs": ["structs"],
+        "colors": ["colors"],
+    }
+    parser = argparse.ArgumentParser(description="Generator for cheatsheet c files for raylib.com",
+                                     epilog="Example: python generate_cheatsheet_code.py -r raylib/src/raylib.h -m raylib/src/raymath.h -o raylib.com/cheatsheet/ # this generates all files")
+    parser.add_argument("module", nargs="?", type=str, help="the name of the module to generate. If not specified, generates all. Must be one of " + ", ".join(modules.keys()))
+    parser.add_argument("-r", "--raylib", dest="inlib", default=sys.stdin, type=str, help="path to the raylib.h header file. If not specified uses stdin")
+    parser.add_argument("-m", "--raymath", dest="inmath", default=sys.stdin, type=str, help="path to the raymath.h header file. If not specified uses stdin")
+    parser.add_argument("-o", "--output", dest="out", default=sys.stdout, type=str, help="the file to generate, or folder if generating all modules")
+    args = parser.parse_args()
+
+    if args.module is not None:
+        module = []
+        try:
+            module = modules[args.module]
+        except KeyError:
+            parser.print_help()
+            print(f"Error: {args.module} is not a valid module")
+        performModule(module, args.inmath, args.inlib, args.out)
+    else:
+        is_stdout = args.out is sys.stdout
+        if not is_stdout and not os.path.exists(args.out):
+            os.mkdir(args.out)
+
+        for mod, modules in modules.items():
+            outp = args.out
+            if not is_stdout:
+                outp += f"/raylib_{mod}.c"
+            performModule(modules, args.inmath, args.inlib, outp)
+
+
+if __name__ == "__main__":
+    main()

--- a/cheatsheet/raylib_audio.c
+++ b/cheatsheet/raylib_audio.c
@@ -1,4 +1,3 @@
-
     // Audio device management functions
     void InitAudioDevice(void);                                     // Initialize audio device and context
     void CloseAudioDevice(void);                                    // Close the audio device and context

--- a/cheatsheet/raylib_colors.c
+++ b/cheatsheet/raylib_colors.c
@@ -1,30 +1,28 @@
+    // Custom raylib color palette for amazing visuals on WHITE background
+    #define LIGHTGRAY  (Color){ 200, 200, 200, 255 }   // Light Gray
+    #define GRAY       (Color){ 130, 130, 130, 255 }   // Gray
+    #define DARKGRAY   (Color){ 80, 80, 80, 255 }      // Dark Gray
+    #define YELLOW     (Color){ 253, 249, 0, 255 }     // Yellow
+    #define GOLD       (Color){ 255, 203, 0, 255 }     // Gold
+    #define ORANGE     (Color){ 255, 161, 0, 255 }     // Orange
+    #define PINK       (Color){ 255, 109, 194, 255 }   // Pink
+    #define RED        (Color){ 230, 41, 55, 255 }     // Red
+    #define MAROON     (Color){ 190, 33, 55, 255 }     // Maroon
+    #define GREEN      (Color){ 0, 228, 48, 255 }      // Green
+    #define LIME       (Color){ 0, 158, 47, 255 }      // Lime
+    #define DARKGREEN  (Color){ 0, 117, 44, 255 }      // Dark Green
+    #define SKYBLUE    (Color){ 102, 191, 255, 255 }   // Sky Blue
+    #define BLUE       (Color){ 0, 121, 241, 255 }     // Blue
+    #define DARKBLUE   (Color){ 0, 82, 172, 255 }      // Dark Blue
+    #define PURPLE     (Color){ 200, 122, 255, 255 }   // Purple
+    #define VIOLET     (Color){ 135, 60, 190, 255 }    // Violet
+    #define DARKPURPLE (Color){ 112, 31, 126, 255 }    // Dark Purple
+    #define BEIGE      (Color){ 211, 176, 131, 255 }   // Beige
+    #define BROWN      (Color){ 127, 106, 79, 255 }    // Brown
+    #define DARKBROWN  (Color){ 76, 63, 47, 255 }      // Dark Brown
 
-    // Custom raylib color palette for amazing visuals
-    #define LIGHTGRAY  (Color){ 200, 200, 200, 255 }        // Light Gray
-    #define GRAY       (Color){ 130, 130, 130, 255 }        // Gray
-    #define DARKGRAY   (Color){ 80, 80, 80, 255 }           // Dark Gray
-    #define YELLOW     (Color){ 253, 249, 0, 255 }          // Yellow
-    #define GOLD       (Color){ 255, 203, 0, 255 }          // Gold
-    #define ORANGE     (Color){ 255, 161, 0, 255 }          // Orange
-    #define PINK       (Color){ 255, 109, 194, 255 }        // Pink
-    #define RED        (Color){ 230, 41, 55, 255 }          // Red
-    #define MAROON     (Color){ 190, 33, 55, 255 }          // Maroon
-    #define GREEN      (Color){ 0, 228, 48, 255 }           // Green
-    #define LIME       (Color){ 0, 158, 47, 255 }           // Lime
-    #define DARKGREEN  (Color){ 0, 117, 44, 255 }           // Dark Green
-    #define SKYBLUE    (Color){ 102, 191, 255, 255 }        // Sky Blue
-    #define BLUE       (Color){ 0, 121, 241, 255 }          // Blue
-    #define DARKBLUE   (Color){ 0, 82, 172, 255 }           // Dark Blue
-    #define PURPLE     (Color){ 200, 122, 255, 255 }        // Purple
-    #define VIOLET     (Color){ 135, 60, 190, 255 }         // Violet
-    #define DARKPURPLE (Color){ 112, 31, 126, 255 }         // Dark Purple
-    #define BEIGE      (Color){ 211, 176, 131, 255 }        // Beige
-    #define BROWN      (Color){ 127, 106, 79, 255 }         // Brown
-    #define DARKBROWN  (Color){ 76, 63, 47, 255 }           // Dark Brown
-
-    #define WHITE      (Color){ 255, 255, 255, 255 }        // White
-    #define BLACK      (Color){ 0, 0, 0, 255 }              // Black
-    #define BLANK      (Color){ 0, 0, 0, 0 }                // Transparent
-    #define MAGENTA    (Color){ 255, 0, 255, 255 }          // Magenta
-    #define RAYWHITE   (Color){ 245, 245, 245, 255 }        // Ray White
-    
+    #define WHITE      (Color){ 255, 255, 255, 255 }   // White
+    #define BLACK      (Color){ 0, 0, 0, 255 }         // Black
+    #define BLANK      (Color){ 0, 0, 0, 0 }           // Blank (Transparent)
+    #define MAGENTA    (Color){ 255, 0, 255, 255 }     // Magenta
+    #define RAYWHITE   (Color){ 245, 245, 245, 255 }   // My own White (raylib logo)

--- a/cheatsheet/raylib_core.c
+++ b/cheatsheet/raylib_core.c
@@ -44,7 +44,7 @@
     const char *GetClipboardText(void);                         // Get clipboard text content
     void EnableEventWaiting(void);                              // Enable waiting for events on EndDrawing(), no automatic event polling
     void DisableEventWaiting(void);                             // Disable waiting for events on EndDrawing(), automatic events polling
-    
+
     // Custom frame control functions
     // NOTE: Those functions are intended for advance users that want full control over the frame processing
     // By default EndDrawing() does this job: draws everything + SwapScreenBuffer() + manage frame timming + PollInputEvents()
@@ -52,7 +52,7 @@
     void SwapScreenBuffer(void);                                // Swap back buffer with front buffer (screen drawing)
     void PollInputEvents(void);                                 // Register all input events
     void WaitTime(double seconds);                              // Wait for some time (halt program execution)
-    
+
     // Cursor-related functions
     void ShowCursor(void);                                      // Shows cursor
     void HideCursor(void);                                      // Hides cursor
@@ -60,7 +60,7 @@
     void EnableCursor(void);                                    // Enables cursor (unlock cursor)
     void DisableCursor(void);                                   // Disables cursor (lock cursor)
     bool IsCursorOnScreen(void);                                // Check if cursor is on the screen
-    
+
     // Drawing-related functions
     void ClearBackground(Color color);                          // Set background color (framebuffer clear color)
     void BeginDrawing(void);                                    // Setup canvas (framebuffer) to start drawing
@@ -79,11 +79,11 @@
     void EndScissorMode(void);                                  // End scissor mode
     void BeginVrStereoMode(VrStereoConfig config);              // Begin stereo rendering (requires VR simulator)
     void EndVrStereoMode(void);                                 // End stereo rendering (requires VR simulator)
-    
+
     // VR stereo config functions for VR simulator
     VrStereoConfig LoadVrStereoConfig(VrDeviceInfo device);     // Load VR stereo config for VR simulator device parameters
     void UnloadVrStereoConfig(VrStereoConfig config);           // Unload VR stereo config
-    
+
     // Shader management functions
     // NOTE: Shader functionality is not available on OpenGL 1.1
     Shader LoadShader(const char *vsFileName, const char *fsFileName);   // Load shader from files and bind default locations
@@ -95,7 +95,7 @@
     void SetShaderValueMatrix(Shader shader, int locIndex, Matrix mat);         // Set shader uniform value (matrix 4x4)
     void SetShaderValueTexture(Shader shader, int locIndex, Texture2D texture); // Set shader uniform value for texture (sampler2d)
     void UnloadShader(Shader shader);                                    // Unload shader from GPU memory (VRAM)
-    
+
     // Screen-space-related functions
     Ray GetMouseRay(Vector2 mousePosition, Camera camera);      // Get a ray trace from mouse position
     Matrix GetCameraMatrix(Camera camera);                      // Get camera transform matrix (view matrix)
@@ -104,27 +104,27 @@
     Vector2 GetScreenToWorld2D(Vector2 position, Camera2D camera); // Get the world space position for a 2d camera screen space position
     Vector2 GetWorldToScreenEx(Vector3 position, Camera camera, int width, int height); // Get size position for a 3d world space position
     Vector2 GetWorldToScreen2D(Vector2 position, Camera2D camera); // Get the screen space position for a 2d camera world space position
-    
+
     // Timing-related functions
     void SetTargetFPS(int fps);                                 // Set target FPS (maximum)
     int GetFPS(void);                                           // Get current FPS
     float GetFrameTime(void);                                   // Get time in seconds for last frame drawn (delta time)
     double GetTime(void);                                       // Get elapsed time in seconds since InitWindow()
-    
+
     // Misc. functions
     int GetRandomValue(int min, int max);                       // Get a random value between min and max (both included)
     void SetRandomSeed(unsigned int seed);                      // Set the seed for the random number generator
     void TakeScreenshot(const char *fileName);                  // Takes a screenshot of current screen (filename extension defines format)
     void SetConfigFlags(unsigned int flags);                    // Setup init configuration flags (view FLAGS)
-    
+
     void TraceLog(int logLevel, const char *text, ...);         // Show trace log messages (LOG_DEBUG, LOG_INFO, LOG_WARNING, LOG_ERROR...)
     void SetTraceLogLevel(int logLevel);                        // Set the current threshold (minimum) log level
     void *MemAlloc(int size);                                   // Internal memory allocator
     void *MemRealloc(void *ptr, int size);                      // Internal memory reallocator
     void MemFree(void *ptr);                                    // Internal memory free
-    
+
     void OpenURL(const char *url);                              // Open URL with default system browser (if available)
-    
+
     // Set custom callbacks
     // WARNING: Callbacks setup is intended for advance users
     void SetTraceLogCallback(TraceLogCallback callback);         // Set custom trace log
@@ -132,7 +132,7 @@
     void SetSaveFileDataCallback(SaveFileDataCallback callback); // Set custom file binary data saver
     void SetLoadFileTextCallback(LoadFileTextCallback callback); // Set custom file text data loader
     void SetSaveFileTextCallback(SaveFileTextCallback callback); // Set custom file text data saver
-    
+
     // Files management functions
     unsigned char *LoadFileData(const char *fileName, unsigned int *bytesRead);       // Load file data as byte array (read)
     void UnloadFileData(unsigned char *data);                   // Unload file data allocated by LoadFileData()
@@ -161,81 +161,81 @@
     FilePathList LoadDroppedFiles(void);                        // Load dropped filepaths
     void UnloadDroppedFiles(FilePathList files);                // Unload dropped filepaths
     long GetFileModTime(const char *fileName);                  // Get file modification time (last write time)
-    
+
     // Compression/Encoding functionality
     unsigned char *CompressData(const unsigned char *data, int dataSize, int *compDataSize);        // Compress data (DEFLATE algorithm), memory must be MemFree()
     unsigned char *DecompressData(const unsigned char *compData, int compDataSize, int *dataSize);  // Decompress data (DEFLATE algorithm), memory must be MemFree()
     char *EncodeDataBase64(const unsigned char *data, int dataSize, int *outputSize);               // Encode data to Base64 string, memory must be MemFree()
     unsigned char *DecodeDataBase64(const unsigned char *data, int *outputSize);                    // Decode Base64 string data, memory must be MemFree()
-    
+
     //------------------------------------------------------------------------------------
     // Input Handling Functions (Module: core)
     //------------------------------------------------------------------------------------
-    
+
     // Input-related functions: keyboard
-    bool IsKeyPressed(int key);                                 // Check if a key has been pressed once
-    bool IsKeyDown(int key);                                    // Check if a key is being pressed
-    bool IsKeyReleased(int key);                                // Check if a key has been released once
-    bool IsKeyUp(int key);                                      // Check if a key is NOT being pressed
-    void SetExitKey(int key);                                   // Set a custom key to exit program (default is ESC)
-    int GetKeyPressed(void);                                    // Get key pressed (keycode), call it multiple times for keys queued, returns 0 when the queue is empty
-    int GetCharPressed(void);                                   // Get char pressed (unicode), call it multiple times for chars queued, returns 0 when the queue is empty
-    
+    bool IsKeyPressed(int key);                             // Check if a key has been pressed once
+    bool IsKeyDown(int key);                                // Check if a key is being pressed
+    bool IsKeyReleased(int key);                            // Check if a key has been released once
+    bool IsKeyUp(int key);                                  // Check if a key is NOT being pressed
+    void SetExitKey(int key);                               // Set a custom key to exit program (default is ESC)
+    int GetKeyPressed(void);                                // Get key pressed (keycode), call it multiple times for keys queued, returns 0 when the queue is empty
+    int GetCharPressed(void);                               // Get char pressed (unicode), call it multiple times for chars queued, returns 0 when the queue is empty
+
     // Input-related functions: gamepads
-    bool IsGamepadAvailable(int gamepad);                       // Check if a gamepad is available
-    const char *GetGamepadName(int gamepad);                    // Get gamepad internal name id
-    bool IsGamepadButtonPressed(int gamepad, int button);       // Check if a gamepad button has been pressed once
-    bool IsGamepadButtonDown(int gamepad, int button);          // Check if a gamepad button is being pressed
-    bool IsGamepadButtonReleased(int gamepad, int button);      // Check if a gamepad button has been released once
-    bool IsGamepadButtonUp(int gamepad, int button);            // Check if a gamepad button is NOT being pressed
-    int GetGamepadButtonPressed(void);                          // Get the last gamepad button pressed
-    int GetGamepadAxisCount(int gamepad);                       // Get gamepad axis count for a gamepad
-    float GetGamepadAxisMovement(int gamepad, int axis);        // Get axis movement value for a gamepad axis
-    int SetGamepadMappings(const char *mappings);               // Set internal gamepad mappings (SDL_GameControllerDB)
-    
+    bool IsGamepadAvailable(int gamepad);                   // Check if a gamepad is available
+    const char *GetGamepadName(int gamepad);                // Get gamepad internal name id
+    bool IsGamepadButtonPressed(int gamepad, int button);   // Check if a gamepad button has been pressed once
+    bool IsGamepadButtonDown(int gamepad, int button);      // Check if a gamepad button is being pressed
+    bool IsGamepadButtonReleased(int gamepad, int button);  // Check if a gamepad button has been released once
+    bool IsGamepadButtonUp(int gamepad, int button);        // Check if a gamepad button is NOT being pressed
+    int GetGamepadButtonPressed(void);                      // Get the last gamepad button pressed
+    int GetGamepadAxisCount(int gamepad);                   // Get gamepad axis count for a gamepad
+    float GetGamepadAxisMovement(int gamepad, int axis);    // Get axis movement value for a gamepad axis
+    int SetGamepadMappings(const char *mappings);           // Set internal gamepad mappings (SDL_GameControllerDB)
+
     // Input-related functions: mouse
-    bool IsMouseButtonPressed(int button);                      // Check if a mouse button has been pressed once
-    bool IsMouseButtonDown(int button);                         // Check if a mouse button is being pressed
-    bool IsMouseButtonReleased(int button);                     // Check if a mouse button has been released once
-    bool IsMouseButtonUp(int button);                           // Check if a mouse button is NOT being pressed
-    int GetMouseX(void);                                        // Get mouse position X
-    int GetMouseY(void);                                        // Get mouse position Y
-    Vector2 GetMousePosition(void);                             // Get mouse position XY
-    Vector2 GetMouseDelta(void);                                // Get mouse delta between frames
-    void SetMousePosition(int x, int y);                        // Set mouse position XY
-    void SetMouseOffset(int offsetX, int offsetY);              // Set mouse offset
-    void SetMouseScale(float scaleX, float scaleY);             // Set mouse scaling
-    float GetMouseWheelMove(void);                              // Get mouse wheel movement for X or Y, whichever is larger
-    Vector2 GetMouseWheelMoveV(void);                           // Get mouse wheel movement for both X and Y
-    void SetMouseCursor(int cursor);                            // Set mouse cursor
-        
-    // Input-related functions: touch   
-    int GetTouchX(void);                                        // Get touch position X for touch point 0 (relative to screen size)
-    int GetTouchY(void);                                        // Get touch position Y for touch point 0 (relative to screen size)
-    Vector2 GetTouchPosition(int index);                        // Get touch position XY for a touch point index (relative to screen size)
-    int GetTouchPointId(int index);                             // Get touch point identifier for given index
-    int GetTouchPointCount(void);                               // Get number of touch points
-    
+    bool IsMouseButtonPressed(int button);                  // Check if a mouse button has been pressed once
+    bool IsMouseButtonDown(int button);                     // Check if a mouse button is being pressed
+    bool IsMouseButtonReleased(int button);                 // Check if a mouse button has been released once
+    bool IsMouseButtonUp(int button);                       // Check if a mouse button is NOT being pressed
+    int GetMouseX(void);                                    // Get mouse position X
+    int GetMouseY(void);                                    // Get mouse position Y
+    Vector2 GetMousePosition(void);                         // Get mouse position XY
+    Vector2 GetMouseDelta(void);                            // Get mouse delta between frames
+    void SetMousePosition(int x, int y);                    // Set mouse position XY
+    void SetMouseOffset(int offsetX, int offsetY);          // Set mouse offset
+    void SetMouseScale(float scaleX, float scaleY);         // Set mouse scaling
+    float GetMouseWheelMove(void);                          // Get mouse wheel movement for X or Y, whichever is larger
+    Vector2 GetMouseWheelMoveV(void);                       // Get mouse wheel movement for both X and Y
+    void SetMouseCursor(int cursor);                        // Set mouse cursor
+
+    // Input-related functions: touch
+    int GetTouchX(void);                                    // Get touch position X for touch point 0 (relative to screen size)
+    int GetTouchY(void);                                    // Get touch position Y for touch point 0 (relative to screen size)
+    Vector2 GetTouchPosition(int index);                    // Get touch position XY for a touch point index (relative to screen size)
+    int GetTouchPointId(int index);                         // Get touch point identifier for given index
+    int GetTouchPointCount(void);                           // Get number of touch points
+
     //------------------------------------------------------------------------------------
     // Gestures and Touch Handling Functions (Module: rgestures)
     //------------------------------------------------------------------------------------
-    void SetGesturesEnabled(unsigned int flags);                // Enable a set of gestures using flags
-    bool IsGestureDetected(int gesture);                        // Check if a gesture have been detected
-    int GetGestureDetected(void);                               // Get latest detected gesture
-    float GetGestureHoldDuration(void);                         // Get gesture hold time in milliseconds
-    Vector2 GetGestureDragVector(void);                         // Get gesture drag vector
-    float GetGestureDragAngle(void);                            // Get gesture drag angle
-    Vector2 GetGesturePinchVector(void);                        // Get gesture pinch delta
-    float GetGesturePinchAngle(void);                           // Get gesture pinch angle
-    
+    void SetGesturesEnabled(unsigned int flags);      // Enable a set of gestures using flags
+    bool IsGestureDetected(int gesture);              // Check if a gesture have been detected
+    int GetGestureDetected(void);                     // Get latest detected gesture
+    float GetGestureHoldDuration(void);               // Get gesture hold time in milliseconds
+    Vector2 GetGestureDragVector(void);               // Get gesture drag vector
+    float GetGestureDragAngle(void);                  // Get gesture drag angle
+    Vector2 GetGesturePinchVector(void);              // Get gesture pinch delta
+    float GetGesturePinchAngle(void);                 // Get gesture pinch angle
+
     //------------------------------------------------------------------------------------
     // Camera System Functions (Module: rcamera)
     //------------------------------------------------------------------------------------
-    void SetCameraMode(Camera camera, int mode);                // Set camera mode (multiple camera modes available)
-    void UpdateCamera(Camera *camera);                          // Update camera position for selected mode
-    
-    void SetCameraPanControl(int keyPan);                       // Set camera pan key to combine with mouse movement (free camera)
-    void SetCameraAltControl(int keyAlt);                       // Set camera alt key to combine with mouse movement (free camera)
-    void SetCameraSmoothZoomControl(int keySmoothZoom);         // Set camera smooth zoom key to combine with mouse (free camera)
+    void SetCameraMode(Camera camera, int mode);      // Set camera mode (multiple camera modes available)
+    void UpdateCamera(Camera *camera);                // Update camera position for selected mode
+
+    void SetCameraPanControl(int keyPan);             // Set camera pan key to combine with mouse movement (free camera)
+    void SetCameraAltControl(int keyAlt);             // Set camera alt key to combine with mouse movement (free camera)
+    void SetCameraSmoothZoomControl(int keySmoothZoom); // Set camera smooth zoom key to combine with mouse (free camera)
     void SetCameraMoveControls(int keyFront, int keyBack, int keyRight, int keyLeft, int keyUp, int keyDown); // Set camera move controls (1st person and 3rd person cameras)
 

--- a/cheatsheet/raylib_math.c
+++ b/cheatsheet/raylib_math.c
@@ -1,0 +1,121 @@
+
+    // Utils math
+    float Clamp(float value, float min, float max)                              // Function specifiers definition Defines and Macros Get float vector for Matrix Get float vector for Vector3 Types and Structures Definition Vector2 type Vector3 type Vector4 type Quaternion type Matrix type (OpenGL style 4x4 - right handed, column major) NOTE: Helper types to be used instead of array return types for *ToFloat functions Clamp float value
+    float Lerp(float start, float end, float amount)                            // Calculate linear interpolation between two floats
+    float Normalize(float value, float start, float end)                        // Normalize input value within input range
+    float Remap(float value, float inputStart, float inputEnd, float outputStart, float outputEnd) // Remap input value within input range to output range
+    float Wrap(float value, float min, float max)                               // Wrap input value from min to max
+    int FloatEquals(float x, float y)                                           // Check whether two given floats are almost equal
+
+    // Vector2 math
+    Vector2 Vector2Zero(void)                                                   // Vector with components value 0.0f
+    Vector2 Vector2One(void)                                                    // Vector with components value 1.0f
+    Vector2 Vector2Add(Vector2 v1, Vector2 v2)                                  // Add two vectors (v1 + v2)
+    Vector2 Vector2AddValue(Vector2 v, float add)                               // Add vector and float value
+    Vector2 Vector2Subtract(Vector2 v1, Vector2 v2)                             // Subtract two vectors (v1 - v2)
+    Vector2 Vector2SubtractValue(Vector2 v, float sub)                          // Subtract vector by float value
+    float Vector2Length(Vector2 v)                                              // Calculate vector length
+    float Vector2LengthSqr(Vector2 v)                                           // Calculate vector square length
+    float Vector2DotProduct(Vector2 v1, Vector2 v2)                             // Calculate two vectors dot product
+    float Vector2Distance(Vector2 v1, Vector2 v2)                               // Calculate distance between two vectors
+    float Vector2DistanceSqr(Vector2 v1, Vector2 v2)                            // Calculate square distance between two vectors
+    float Vector2Angle(Vector2 v1, Vector2 v2)                                  // Calculate angle from two vectors
+    Vector2 Vector2Scale(Vector2 v, float scale)                                // Scale vector (multiply by value)
+    Vector2 Vector2Multiply(Vector2 v1, Vector2 v2)                             // Multiply vector by vector
+    Vector2 Vector2Negate(Vector2 v)                                            // Negate vector
+    Vector2 Vector2Divide(Vector2 v1, Vector2 v2)                               // Divide vector by vector
+    Vector2 Vector2Normalize(Vector2 v)                                         // Normalize provided vector
+    Vector2 Vector2Transform(Vector2 v, Matrix mat)                             // Transforms a Vector2 by a given Matrix
+    Vector2 Vector2Lerp(Vector2 v1, Vector2 v2, float amount)                   // Calculate linear interpolation between two vectors
+    Vector2 Vector2Reflect(Vector2 v, Vector2 normal)                           // Calculate reflected vector to normal
+    Vector2 Vector2Rotate(Vector2 v, float angle)                               // Rotate vector by angle
+    Vector2 Vector2MoveTowards(Vector2 v, Vector2 target, float maxDistance)    // Move Vector towards target
+    Vector2 Vector2Invert(Vector2 v)                                            // Invert the given vector
+    Vector2 Vector2Clamp(Vector2 v, Vector2 min, Vector2 max)                   // Clamp the components of the vector between min and max values specified by the given vectors
+    Vector2 Vector2ClampValue(Vector2 v, float min, float max)                  // Clamp the magnitude of the vector between two min and max values
+    int Vector2Equals(Vector2 p, Vector2 q)                                     // Check whether two given vectors are almost equal
+
+    // Vector3 math
+    Vector3 Vector3Zero(void)                                                   // Vector with components value 0.0f
+    Vector3 Vector3One(void)                                                    // Vector with components value 1.0f
+    Vector3 Vector3Add(Vector3 v1, Vector3 v2)                                  // Add two vectors
+    Vector3 Vector3AddValue(Vector3 v, float add)                               // Add vector and float value
+    Vector3 Vector3Subtract(Vector3 v1, Vector3 v2)                             // Subtract two vectors
+    Vector3 Vector3SubtractValue(Vector3 v, float sub)                          // Subtract vector by float value
+    Vector3 Vector3Scale(Vector3 v, float scalar)                               // Multiply vector by scalar
+    Vector3 Vector3Multiply(Vector3 v1, Vector3 v2)                             // Multiply vector by vector
+    Vector3 Vector3CrossProduct(Vector3 v1, Vector3 v2)                         // Calculate two vectors cross product
+    Vector3 Vector3Perpendicular(Vector3 v)                                     // Calculate one vector perpendicular vector
+    float Vector3Length(const Vector3 v)                                        // Calculate vector length
+    float Vector3LengthSqr(const Vector3 v)                                     // Calculate vector square length
+    float Vector3DotProduct(Vector3 v1, Vector3 v2)                             // Calculate two vectors dot product
+    float Vector3Distance(Vector3 v1, Vector3 v2)                               // Calculate distance between two vectors
+    float Vector3DistanceSqr(Vector3 v1, Vector3 v2)                            // Calculate square distance between two vectors
+    float Vector3Angle(Vector3 v1, Vector3 v2)                                  // Calculate angle between two vectors
+    Vector3 Vector3Negate(Vector3 v)                                            // Negate provided vector (invert direction)
+    Vector3 Vector3Divide(Vector3 v1, Vector3 v2)                               // Divide vector by vector
+    Vector3 Vector3Normalize(Vector3 v)                                         // Normalize provided vector
+    void Vector3OrthoNormalize(Vector3 *v1, Vector3 *v2)                        // Orthonormalize provided vectors Makes vectors normalized and orthogonal to each other Gram-Schmidt function implementation
+    Vector3 Vector3Transform(Vector3 v, Matrix mat)                             // Transforms a Vector3 by a given Matrix
+    Vector3 Vector3RotateByQuaternion(Vector3 v, Quaternion q)                  // Transform a vector by quaternion rotation
+    Vector3 Vector3RotateByAxisAngle(Vector3 v, Vector3 axis, float angle)      // Rotates a vector around an axis
+    Vector3 Vector3Lerp(Vector3 v1, Vector3 v2, float amount)                   // Calculate linear interpolation between two vectors
+    Vector3 Vector3Reflect(Vector3 v, Vector3 normal)                           // Calculate reflected vector to normal
+    Vector3 Vector3Min(Vector3 v1, Vector3 v2)                                  // Get min value for each pair of components
+    Vector3 Vector3Max(Vector3 v1, Vector3 v2)                                  // Get max value for each pair of components
+    Vector3 Vector3Barycenter(Vector3 p, Vector3 a, Vector3 b, Vector3 c)       // Compute barycenter coordinates (u, v, w) for point p with respect to triangle (a, b, c) NOTE: Assumes P is on the plane of the triangle
+    Vector3 Vector3Unproject(Vector3 source, Matrix projection, Matrix view)    // Projects a Vector3 from screen space into object space NOTE: We are avoiding calling other raymath functions despite available
+    float3 Vector3ToFloatV(Vector3 v)                                           // Get Vector3 as float array
+    Vector3 Vector3Invert(Vector3 v)                                            // Invert the given vector
+    Vector3 Vector3Clamp(Vector3 v, Vector3 min, Vector3 max)                   // Clamp the components of the vector between min and max values specified by the given vectors
+    Vector3 Vector3ClampValue(Vector3 v, float min, float max)                  // Clamp the magnitude of the vector between two values
+    int Vector3Equals(Vector3 p, Vector3 q)                                     // Check whether two given vectors are almost equal
+    Vector3 Vector3Refract(Vector3 v, Vector3 n, float r)                       // Compute the direction of a refracted ray where v specifies the normalized direction of the incoming ray, n specifies the normalized normal vector of the interface of two optical media, and r specifies the ratio of the refractive index of the medium from where the ray comes to the refractive index of the medium on the other side of the surface
+
+    // Matrix math
+    float MatrixDeterminant(Matrix mat)                                         // Compute matrix determinant
+    float MatrixTrace(Matrix mat)                                               // Get the trace of the matrix (sum of the values along the diagonal)
+    Matrix MatrixTranspose(Matrix mat)                                          // Transposes provided matrix
+    Matrix MatrixInvert(Matrix mat)                                             // Invert provided matrix
+    Matrix MatrixIdentity(void)                                                 // Get identity matrix
+    Matrix MatrixAdd(Matrix left, Matrix right)                                 // Add two matrices
+    Matrix MatrixSubtract(Matrix left, Matrix right)                            // Subtract two matrices (left - right)
+    Matrix MatrixMultiply(Matrix left, Matrix right)                            // Get two matrix multiplication NOTE: When multiplying matrices... the order matters!
+    Matrix MatrixTranslate(float x, float y, float z)                           // Get translation matrix
+    Matrix MatrixRotate(Vector3 axis, float angle)                              // Create rotation matrix from axis and angle NOTE: Angle should be provided in radians
+    Matrix MatrixRotateX(float angle)                                           // Get x-rotation matrix NOTE: Angle must be provided in radians
+    Matrix MatrixRotateY(float angle)                                           // Get y-rotation matrix NOTE: Angle must be provided in radians
+    Matrix MatrixRotateZ(float angle)                                           // Get z-rotation matrix NOTE: Angle must be provided in radians
+    Matrix MatrixRotateXYZ(Vector3 angle)                                       // Get xyz-rotation matrix NOTE: Angle must be provided in radians
+    Matrix MatrixRotateZYX(Vector3 angle)                                       // Get zyx-rotation matrix NOTE: Angle must be provided in radians
+    Matrix MatrixScale(float x, float y, float z)                               // Get scaling matrix
+    Matrix MatrixFrustum(double left, double right, double bottom, double top, double near, double far) // Get perspective projection matrix
+    Matrix MatrixPerspective(double fovy, double aspect, double near, double far) // Get perspective projection matrix NOTE: Fovy angle must be provided in radians
+    Matrix MatrixOrtho(double left, double right, double bottom, double top, double near, double far) // Get orthographic projection matrix
+    Matrix MatrixLookAt(Vector3 eye, Vector3 target, Vector3 up)                // Get camera look-at matrix (view matrix)
+    float16 MatrixToFloatV(Matrix mat)                                          // Get float array of matrix data
+
+    // Quaternion math
+    Quaternion QuaternionAdd(Quaternion q1, Quaternion q2)                      // Add two quaternions
+    Quaternion QuaternionAddValue(Quaternion q, float add)                      // Add quaternion and float value
+    Quaternion QuaternionSubtract(Quaternion q1, Quaternion q2)                 // Subtract two quaternions
+    Quaternion QuaternionSubtractValue(Quaternion q, float sub)                 // Subtract quaternion and float value
+    Quaternion QuaternionIdentity(void)                                         // Get identity quaternion
+    float QuaternionLength(Quaternion q)                                        // Computes the length of a quaternion
+    Quaternion QuaternionNormalize(Quaternion q)                                // Normalize provided quaternion
+    Quaternion QuaternionInvert(Quaternion q)                                   // Invert provided quaternion
+    Quaternion QuaternionMultiply(Quaternion q1, Quaternion q2)                 // Calculate two quaternion multiplication
+    Quaternion QuaternionScale(Quaternion q, float mul)                         // Scale quaternion by float value
+    Quaternion QuaternionDivide(Quaternion q1, Quaternion q2)                   // Divide two quaternions
+    Quaternion QuaternionLerp(Quaternion q1, Quaternion q2, float amount)       // Calculate linear interpolation between two quaternions
+    Quaternion QuaternionNlerp(Quaternion q1, Quaternion q2, float amount)      // Calculate slerp-optimized interpolation between two quaternions
+    Quaternion QuaternionSlerp(Quaternion q1, Quaternion q2, float amount)      // Calculates spherical linear interpolation between two quaternions
+    Quaternion QuaternionFromVector3ToVector3(Vector3 from, Vector3 to)         // Calculate quaternion based on the rotation from one vector to another
+    Quaternion QuaternionFromMatrix(Matrix mat)                                 // Get a quaternion for a given rotation matrix
+    Matrix QuaternionToMatrix(Quaternion q)                                     // Get a matrix for a given quaternion
+    Quaternion QuaternionFromAxisAngle(Vector3 axis, float angle)               // Get rotation quaternion for an angle and axis NOTE: Angle must be provided in radians
+    void QuaternionToAxisAngle(Quaternion q, Vector3 *outAxis, float *outAngle) // Get the rotation angle and axis for a given quaternion
+    Quaternion QuaternionFromEuler(float pitch, float yaw, float roll)          // Get the quaternion equivalent to Euler angles NOTE: Rotation order is ZYX
+    Vector3 QuaternionToEuler(Quaternion q)                                     // Get the Euler angles equivalent to quaternion (roll, pitch, yaw) NOTE: Angles are returned in a Vector3 struct in radians
+    Quaternion QuaternionTransform(Quaternion q, Matrix mat)                    // Transform a quaternion given a transformation matrix
+    int QuaternionEquals(Quaternion p, Quaternion q)                            // Check whether two given quaternions are almost equal

--- a/cheatsheet/raylib_models.c
+++ b/cheatsheet/raylib_models.c
@@ -1,26 +1,25 @@
-
     // Basic geometric 3D shapes drawing functions
-    void DrawLine3D(Vector3 startPos, Vector3 endPos, Color color);                                 // Draw a line in 3D world space
-    void DrawPoint3D(Vector3 position, Color color);                                                // Draw a point in 3D space, actually a small line
+    void DrawLine3D(Vector3 startPos, Vector3 endPos, Color color);                                    // Draw a line in 3D world space
+    void DrawPoint3D(Vector3 position, Color color);                                                   // Draw a point in 3D space, actually a small line
     void DrawCircle3D(Vector3 center, float radius, Vector3 rotationAxis, float rotationAngle, Color color); // Draw a circle in 3D world space
-    void DrawTriangle3D(Vector3 v1, Vector3 v2, Vector3 v3, Color color);                           // Draw a color-filled triangle (vertex in counter-clockwise order!)
-    void DrawTriangleStrip3D(Vector3 *points, int pointCount, Color color);                         // Draw a triangle strip defined by points
-    void DrawCube(Vector3 position, float width, float height, float length, Color color);          // Draw cube
-    void DrawCubeV(Vector3 position, Vector3 size, Color color);                                    // Draw cube (Vector version)
-    void DrawCubeWires(Vector3 position, float width, float height, float length, Color color);     // Draw cube wires
-    void DrawCubeWiresV(Vector3 position, Vector3 size, Color color);                               // Draw cube wires (Vector version)
+    void DrawTriangle3D(Vector3 v1, Vector3 v2, Vector3 v3, Color color);                              // Draw a color-filled triangle (vertex in counter-clockwise order!)
+    void DrawTriangleStrip3D(Vector3 *points, int pointCount, Color color);                            // Draw a triangle strip defined by points
+    void DrawCube(Vector3 position, float width, float height, float length, Color color);             // Draw cube
+    void DrawCubeV(Vector3 position, Vector3 size, Color color);                                       // Draw cube (Vector version)
+    void DrawCubeWires(Vector3 position, float width, float height, float length, Color color);        // Draw cube wires
+    void DrawCubeWiresV(Vector3 position, Vector3 size, Color color);                                  // Draw cube wires (Vector version)
     void DrawCubeTexture(Texture2D texture, Vector3 position, float width, float height, float length, Color color); // Draw cube textured
     void DrawCubeTextureRec(Texture2D texture, Rectangle source, Vector3 position, float width, float height, float length, Color color); // Draw cube with a region of a texture
-    void DrawSphere(Vector3 centerPos, float radius, Color color);                                  // Draw sphere
-    void DrawSphereEx(Vector3 centerPos, float radius, int rings, int slices, Color color);         // Draw sphere with extended parameters
-    void DrawSphereWires(Vector3 centerPos, float radius, int rings, int slices, Color color);      // Draw sphere wires
+    void DrawSphere(Vector3 centerPos, float radius, Color color);                                     // Draw sphere
+    void DrawSphereEx(Vector3 centerPos, float radius, int rings, int slices, Color color);            // Draw sphere with extended parameters
+    void DrawSphereWires(Vector3 centerPos, float radius, int rings, int slices, Color color);         // Draw sphere wires
     void DrawCylinder(Vector3 position, float radiusTop, float radiusBottom, float height, int slices, Color color); // Draw a cylinder/cone
     void DrawCylinderEx(Vector3 startPos, Vector3 endPos, float startRadius, float endRadius, int sides, Color color); // Draw a cylinder with base at startPos and top at endPos
     void DrawCylinderWires(Vector3 position, float radiusTop, float radiusBottom, float height, int slices, Color color); // Draw a cylinder/cone wires
     void DrawCylinderWiresEx(Vector3 startPos, Vector3 endPos, float startRadius, float endRadius, int sides, Color color); // Draw a cylinder wires with base at startPos and top at endPos
-    void DrawPlane(Vector3 centerPos, Vector2 size, Color color);                                   // Draw a plane XZ
-    void DrawRay(Ray ray, Color color);                                                             // Draw a ray line
-    void DrawGrid(int slices, float spacing);                                                       // Draw a grid (centered at (0, 0, 0))
+    void DrawPlane(Vector3 centerPos, Vector2 size, Color color);                                      // Draw a plane XZ
+    void DrawRay(Ray ray, Color color);                                                                // Draw a ray line
+    void DrawGrid(int slices, float spacing);                                                          // Draw a grid (centered at (0, 0, 0))
 
     //------------------------------------------------------------------------------------
     // Model 3d Loading and Drawing Functions (Module: models)
@@ -34,51 +33,51 @@
     BoundingBox GetModelBoundingBox(Model model);                                         // Compute model bounding box limits (considers all meshes)
 
     // Model drawing functions
-    void DrawModel(Model model, Vector3 position, float scale, Color tint);                       // Draw a model (with texture if set)
+    void DrawModel(Model model, Vector3 position, float scale, Color tint);                           // Draw a model (with texture if set)
     void DrawModelEx(Model model, Vector3 position, Vector3 rotationAxis, float rotationAngle, Vector3 scale, Color tint); // Draw a model with extended parameters
-    void DrawModelWires(Model model, Vector3 position, float scale, Color tint);                  // Draw a model wires (with texture if set)
+    void DrawModelWires(Model model, Vector3 position, float scale, Color tint);                      // Draw a model wires (with texture if set)
     void DrawModelWiresEx(Model model, Vector3 position, Vector3 rotationAxis, float rotationAngle, Vector3 scale, Color tint); // Draw a model wires (with texture if set) with extended parameters
-    void DrawBoundingBox(BoundingBox box, Color color);                                           // Draw bounding box (wires)
-    void DrawBillboard(Camera camera, Texture2D texture, Vector3 position, float size, Color tint); // Draw a billboard texture
+    void DrawBoundingBox(BoundingBox box, Color color);                                               // Draw bounding box (wires)
+    void DrawBillboard(Camera camera, Texture2D texture, Vector3 position, float size, Color tint);   // Draw a billboard texture
     void DrawBillboardRec(Camera camera, Texture2D texture, Rectangle source, Vector3 position, Vector2 size, Color tint); // Draw a billboard texture defined by source
     void DrawBillboardPro(Camera camera, Texture2D texture, Rectangle source, Vector3 position, Vector3 up, Vector2 size, Vector2 origin, float rotation, Color tint); // Draw a billboard texture defined by source and rotation
 
     // Mesh management functions
-    void UploadMesh(Mesh *mesh, bool dynamic);                                                    // Upload mesh vertex data in GPU and provide VAO/VBO ids
-    void UpdateMeshBuffer(Mesh mesh, int index, const void *data, int dataSize, int offset);      // Update mesh vertex data in GPU for a specific buffer index
-    void UnloadMesh(Mesh mesh);                                                                   // Unload mesh data from CPU and GPU
-    void DrawMesh(Mesh mesh, Material material, Matrix transform);                                // Draw a 3d mesh with material and transform
+    void UploadMesh(Mesh *mesh, bool dynamic);                                            // Upload mesh vertex data in GPU and provide VAO/VBO ids
+    void UpdateMeshBuffer(Mesh mesh, int index, const void *data, int dataSize, int offset); // Update mesh vertex data in GPU for a specific buffer index
+    void UnloadMesh(Mesh mesh);                                                           // Unload mesh data from CPU and GPU
+    void DrawMesh(Mesh mesh, Material material, Matrix transform);                        // Draw a 3d mesh with material and transform
     void DrawMeshInstanced(Mesh mesh, Material material, const Matrix *transforms, int instances); // Draw multiple mesh instances with material and different transforms
-    bool ExportMesh(Mesh mesh, const char *fileName);                                             // Export mesh data to file, returns true on success
-    BoundingBox GetMeshBoundingBox(Mesh mesh);                                                    // Compute mesh bounding box limits
-    void GenMeshTangents(Mesh *mesh);                                                             // Compute mesh tangents
+    bool ExportMesh(Mesh mesh, const char *fileName);                                     // Export mesh data to file, returns true on success
+    BoundingBox GetMeshBoundingBox(Mesh mesh);                                            // Compute mesh bounding box limits
+    void GenMeshTangents(Mesh *mesh);                                                     // Compute mesh tangents
 
-    // Mesh generation functions                                                                  
-    Mesh GenMeshPoly(int sides, float radius);                                                    // Generate polygonal mesh
-    Mesh GenMeshPlane(float width, float length, int resX, int resZ);                             // Generate plane mesh (with subdivisions)
-    Mesh GenMeshCube(float width, float height, float length);                                    // Generate cuboid mesh
-    Mesh GenMeshSphere(float radius, int rings, int slices);                                      // Generate sphere mesh (standard sphere)
-    Mesh GenMeshHemiSphere(float radius, int rings, int slices);                                  // Generate half-sphere mesh (no bottom cap)
-    Mesh GenMeshCylinder(float radius, float height, int slices);                                 // Generate cylinder mesh
-    Mesh GenMeshCone(float radius, float height, int slices);                                     // Generate cone/pyramid mesh
-    Mesh GenMeshTorus(float radius, float size, int radSeg, int sides);                           // Generate torus mesh
-    Mesh GenMeshKnot(float radius, float size, int radSeg, int sides);                            // Generate trefoil knot mesh
-    Mesh GenMeshHeightmap(Image heightmap, Vector3 size);                                         // Generate heightmap mesh from image data
-    Mesh GenMeshCubicmap(Image cubicmap, Vector3 cubeSize);                                       // Generate cubes-based map mesh from image data
-                                                                                                  
-    // Material loading/unloading functions                                                       
-    Material *LoadMaterials(const char *fileName, int *materialCount);                            // Load materials from model file
-    Material LoadMaterialDefault(void);                                                           // Load default material (Supports: DIFFUSE, SPECULAR, NORMAL maps)
-    void UnloadMaterial(Material material);                                                       // Unload material from GPU memory (VRAM)
-    void SetMaterialTexture(Material *material, int mapType, Texture2D texture);                  // Set texture for a material map type (MATERIAL_MAP_DIFFUSE, MATERIAL_MAP_SPECULAR...)
-    void SetModelMeshMaterial(Model *model, int meshId, int materialId);                          // Set material for a mesh
-                                                                                                  
-    // Model animations loading/unloading functions                                               
-    ModelAnimation *LoadModelAnimations(const char *fileName, unsigned int *animCount);           // Load model animations from file
-    void UpdateModelAnimation(Model model, ModelAnimation anim, int frame);                       // Update model animation pose
-    void UnloadModelAnimation(ModelAnimation anim);                                               // Unload animation data
-    void UnloadModelAnimations(ModelAnimation *animations, unsigned int count);                   // Unload animation array data
-    bool IsModelAnimationValid(Model model, ModelAnimation anim);                                 // Check model animation skeleton match
+    // Mesh generation functions
+    Mesh GenMeshPoly(int sides, float radius);                                            // Generate polygonal mesh
+    Mesh GenMeshPlane(float width, float length, int resX, int resZ);                     // Generate plane mesh (with subdivisions)
+    Mesh GenMeshCube(float width, float height, float length);                            // Generate cuboid mesh
+    Mesh GenMeshSphere(float radius, int rings, int slices);                              // Generate sphere mesh (standard sphere)
+    Mesh GenMeshHemiSphere(float radius, int rings, int slices);                          // Generate half-sphere mesh (no bottom cap)
+    Mesh GenMeshCylinder(float radius, float height, int slices);                         // Generate cylinder mesh
+    Mesh GenMeshCone(float radius, float height, int slices);                             // Generate cone/pyramid mesh
+    Mesh GenMeshTorus(float radius, float size, int radSeg, int sides);                   // Generate torus mesh
+    Mesh GenMeshKnot(float radius, float size, int radSeg, int sides);                    // Generate trefoil knot mesh
+    Mesh GenMeshHeightmap(Image heightmap, Vector3 size);                                 // Generate heightmap mesh from image data
+    Mesh GenMeshCubicmap(Image cubicmap, Vector3 cubeSize);                               // Generate cubes-based map mesh from image data
+
+    // Material loading/unloading functions
+    Material *LoadMaterials(const char *fileName, int *materialCount);                    // Load materials from model file
+    Material LoadMaterialDefault(void);                                                   // Load default material (Supports: DIFFUSE, SPECULAR, NORMAL maps)
+    void UnloadMaterial(Material material);                                               // Unload material from GPU memory (VRAM)
+    void SetMaterialTexture(Material *material, int mapType, Texture2D texture);          // Set texture for a material map type (MATERIAL_MAP_DIFFUSE, MATERIAL_MAP_SPECULAR...)
+    void SetModelMeshMaterial(Model *model, int meshId, int materialId);                  // Set material for a mesh
+
+    // Model animations loading/unloading functions
+    ModelAnimation *LoadModelAnimations(const char *fileName, unsigned int *animCount);   // Load model animations from file
+    void UpdateModelAnimation(Model model, ModelAnimation anim, int frame);               // Update model animation pose
+    void UnloadModelAnimation(ModelAnimation anim);                                       // Unload animation data
+    void UnloadModelAnimations(ModelAnimation *animations, unsigned int count);           // Unload animation array data
+    bool IsModelAnimationValid(Model model, ModelAnimation anim);                         // Check model animation skeleton match
 
     // Collision detection functions
     bool CheckCollisionSpheres(Vector3 center1, float radius1, Vector3 center2, float radius2);   // Check collision between two spheres

--- a/cheatsheet/raylib_shapes.c
+++ b/cheatsheet/raylib_shapes.c
@@ -1,5 +1,3 @@
-
-    // Set texture and rectangle to be used on shapes drawing
     // NOTE: It can be useful when using basic shapes and one single font,
     // defining a font char white rectangle would allow drawing everything in a single draw call
     void SetShapesTexture(Texture2D texture, Rectangle source);       // Set texture and rectangle to be used on shapes drawing

--- a/cheatsheet/raylib_structs.c
+++ b/cheatsheet/raylib_structs.c
@@ -1,42 +1,38 @@
+    struct Vector2;                // Vector2, 2 components
+    struct Vector3;                // Vector3, 3 components
+    struct Vector4;                // Vector4, 4 components
+    struct Matrix;                 // Matrix, 4x4 components, column major, OpenGL style, right handed
+    struct Color;                  // Color, 4 components, R8G8B8A8 (32bit)
+    struct Rectangle;              // Rectangle, 4 components
 
-    struct Vector2;         // Vector2 type
-    struct Vector3;         // Vector3 type
-    struct Vector4;         // Vector4 type
-    struct Quaternion;      // Quaternion type
-    struct Matrix;          // Matrix type (OpenGL style 4x4)
-    struct Color;           // Color type, RGBA (32bit)
-    struct Rectangle;       // Rectangle type
-    
-    struct Image;           // Image type (multiple pixel formats supported)
-                            // NOTE: Data stored in CPU memory (RAM)               
-    struct Texture;         // Texture type (multiple internal formats supported)
-                            // NOTE: Data stored in GPU memory (VRAM)
-    struct RenderTexture;   // RenderTexture type, for texture rendering
-    struct NPatchInfo;      // N-Patch layout info
-    struct GlyphInfo;       // Font character glyph info
-    struct Font;            // Font type, includes texture and chars data
-    
-    struct Camera;          // Camera type, defines 3d camera position/orientation
-    struct Camera2D;        // Camera2D type, defines a 2d camera
-    struct Mesh;            // Vertex data definning a mesh
-    struct Shader;          // Shader type (generic shader)
-    struct MaterialMap;     // Material texture map
-    struct Material;        // Material type
-    struct Model;           // Basic 3d Model type
-    struct Transform;       // Transformation (used for bones)
-    struct BoneInfo;        // Bone information
-    struct ModelAnimation;  // Model animation data (bones and frames)
-    struct Ray;             // Ray type (useful for raycast)
-    struct RayCollision;    // Raycast hit information
-    struct BoundingBox;     // Bounding box type for 3d mesh
-    
-    struct Wave;            // Wave type, defines audio wave data
-    struct Sound;           // Basic Sound source and buffer
-    struct Music;           // Music type (file streaming from memory)
-    struct AudioStream;     // Raw audio stream type
-    
-    struct VrDeviceInfo;    // VR device parameters
-    struct VrStereoConfig;  // VR Stereo rendering configuration for simulator
-    
-    struct FilePathList;    // File path list
-    
+    struct Image;                  // Image, pixel data stored in CPU memory (RAM)
+    struct Texture;                // Texture, tex data stored in GPU memory (VRAM)
+    struct RenderTexture;          // RenderTexture, fbo for texture rendering
+    struct NPatchInfo;             // NPatchInfo, n-patch layout info
+    struct GlyphInfo;              // GlyphInfo, font characters glyphs info
+    struct Font;                   // Font, font texture and GlyphInfo array data
+
+    struct Camera3D;               // Camera, defines position/orientation in 3d space
+
+    struct Camera2D;               // Camera2D, defines position/orientation in 2d space
+    struct Mesh;                   // Mesh, vertex data and vao/vbo
+    struct Shader;                 // Shader
+    struct MaterialMap;            // MaterialMap
+    struct Material;               // Material, includes shader and maps
+    struct Transform;              // Transform, vectex transformation data
+    struct BoneInfo;               // Bone, skeletal animation bone
+    struct Model;                  // Model, meshes, materials and animation data
+    struct ModelAnimation;         // ModelAnimation
+    struct Ray;                    // Ray, ray for raycasting
+    struct RayCollision;           // RayCollision, ray hit information
+    struct BoundingBox;            // BoundingBox
+
+    struct Wave;                   // Wave, audio wave data
+    struct AudioStream;            // AudioStream, custom audio stream
+    struct Sound;                  // Sound
+    struct Music;                  // Music, audio stream, anything longer than ~10 seconds should be streamed
+
+    struct VrDeviceInfo;           // VrDeviceInfo, Head-Mounted-Display device parameters
+    struct VrStereoConfig;         // VrStereoConfig, VR stereo rendering configuration for simulator
+
+    struct FilePathList;           // File path list

--- a/cheatsheet/raylib_text.c
+++ b/cheatsheet/raylib_text.c
@@ -1,4 +1,3 @@
-
     // Font loading/unloading functions
     Font GetFontDefault(void);                                                            // Get the default Font
     Font LoadFont(const char *fileName);                                                  // Load font from file into GPU memory (VRAM)
@@ -27,12 +26,12 @@
     Rectangle GetGlyphAtlasRec(Font font, int codepoint);                                 // Get glyph rectangle in font atlas for a codepoint (unicode character), fallback to '?' if not found
 
     // Text codepoints management functions (unicode characters)
-    int *LoadCodepoints(const char *text, int *count);                                    // Load all codepoints from a UTF-8 text string, codepoints count returned by parameter
-    void UnloadCodepoints(int *codepoints);                                               // Unload codepoints data from memory
-    int GetCodepointCount(const char *text);                                              // Get total number of codepoints in a UTF-8 encoded string
-    int GetCodepoint(const char *text, int *bytesProcessed);                              // Get next codepoint in a UTF-8 encoded string, 0x3f('?') is returned on failure
-    const char *CodepointToUTF8(int codepoint, int *byteSize);                            // Encode one codepoint into UTF-8 byte array (array length returned as parameter)
-    char *TextCodepointsToUTF8(const int *codepoints, int length);                        // Encode text as codepoints array into UTF-8 text string (WARNING: memory must be freed!)
+    int *LoadCodepoints(const char *text, int *count);              // Load all codepoints from a UTF-8 text string, codepoints count returned by parameter
+    void UnloadCodepoints(int *codepoints);                         // Unload codepoints data from memory
+    int GetCodepointCount(const char *text);                        // Get total number of codepoints in a UTF-8 encoded string
+    int GetCodepoint(const char *text, int *bytesProcessed);        // Get next codepoint in a UTF-8 encoded string, 0x3f('?') is returned on failure
+    const char *CodepointToUTF8(int codepoint, int *byteSize);      // Encode one codepoint into UTF-8 byte array (array length returned as parameter)
+    char *TextCodepointsToUTF8(const int *codepoints, int length);  // Encode text as codepoints array into UTF-8 text string (WARNING: memory must be freed!)
 
     // Text strings management functions (no UTF-8 strings, only byte chars)
     // NOTE: Some strings allocate memory internally for returned strings, just be careful!
@@ -47,8 +46,8 @@
     const char **TextSplit(const char *text, char delimiter, int *count);                 // Split text into multiple strings
     void TextAppend(char *text, const char *append, int *position);                       // Append text at specific position and move cursor!
     int TextFindIndex(const char *text, const char *find);                                // Find first text occurrence within a string
-    const char *TextToUpper(const char *text);                                            // Get upper case version of provided string
-    const char *TextToLower(const char *text);                                            // Get lower case version of provided string
-    const char *TextToPascal(const char *text);                                           // Get Pascal case notation version of provided string
-    int TextToInteger(const char *text);                                                  // Get integer value from text (negative values not supported)
+    const char *TextToUpper(const char *text);                      // Get upper case version of provided string
+    const char *TextToLower(const char *text);                      // Get lower case version of provided string
+    const char *TextToPascal(const char *text);                     // Get Pascal case notation version of provided string
+    int TextToInteger(const char *text);                            // Get integer value from text (negative values not supported)
 

--- a/cheatsheet/raylib_textures.c
+++ b/cheatsheet/raylib_textures.c
@@ -1,4 +1,3 @@
-
     // Image loading functions
     // NOTE: This functions do not require GPU access
     Image LoadImage(const char *fileName);                                                             // Load image from file into CPU memory (RAM)

--- a/cheatsheet/raymath_cheatsheet.html
+++ b/cheatsheet/raymath_cheatsheet.html
@@ -49,14 +49,7 @@
              border:4px solid #898888; font-family: grixel_acme_7_wide_xtnd, Courier New, Verdana, Arial;
          }
          .exdownbtn:hover{background-color:#f0d6d6; color:#c55757; border:4px solid #e66666;}
-         #core pre code{border:10px solid; border-color:#888888; background-color:#dbdbe1; }
-         #shapes pre code{border:10px solid; border-color:#e66666; background-color:#e9d0d6; }
-         #textures pre code{border:10px solid; border-color:#75a06d; background-color:#c3e4bf; }
-         #text pre code{border:10px solid; border-color:#52b296; background-color:#b9e9dd; }
-         #models pre code{border:10px solid; border-color:#5d9cbd; background-color:#b9d6e8; }
-         #audio pre code{border:10px solid; border-color:#d3b157; background-color:#e5d7ae; }
-         #structs pre code{border:10px solid; border-color:#d2c9c6; background-color:#f8f8ff;}
-         #colors pre code{border:10px solid; border-color:#c6d2c6; background-color:#e9f1f2;}
+         #math pre code{border:10px solid; border-color:#c170ff; background-color:#deb3ff; }
          #logo{width:128px; height:128px; float:left; position:relative; background-image:url(../common/img/raylib_logo.png);}
          #header{position:relative; height:110px; width: 1000px;}
          #title, #plinks, #version{position:relative; float:left; margin:0px; margin-left:10px; margin-top:10px;}
@@ -64,14 +57,7 @@
          #plinks a, #copyright a{color: gray; text-decoration:none;}
          #plinks a:hover{color: black;}
          #version {margin-top: 23px; width:500px;}
-         #pcore{margin-bottom:-12px; margin-left:12px; color:#5c5a5a;}
-         #pshapes{margin-bottom:-12px; margin-left:12px; color:#c55757;}
-         #ptextures{margin-bottom:-12px; margin-left:12px; color:#60815a;}
-         #ptext{margin-bottom:-12px; margin-left:12px; color:#377764;}
-         #pmodels{margin-bottom:-12px; margin-left:12px; color:#417794;}
-         #paudio{margin-bottom:-12px; margin-left:12px; color:#8c7539;}
-         #pstructs{margin-bottom:-12px; margin-left:12px; color:#bcbccd;}
-         #pcolors{margin-bottom:-12px; margin-left:12px; color:#bcbccd;}
+         #pmath{margin-bottom:-12px; margin-left:12px; color:#9d1cff;}
 
          #fullgroup{
              display: grid;
@@ -88,37 +74,9 @@
 
         <script type="text/javascript">
          $(document).ready(function() {
-             $.get('raylib_core.c', function(data) {
-                 $('#core pre code').text(data);
-                 $('#core pre code').each(function(i, e) {hljs.highlightBlock(e)});
-             }, 'text');
-             $.get('raylib_shapes.c', function(data) {
-                 $('#shapes pre code').text(data);
-                 $('#shapes pre code').each(function(i, e) {hljs.highlightBlock(e)});
-             }, 'text');
-             $.get('raylib_textures.c', function(data) {
-                 $('#textures pre code').text(data);
-                 $('#textures pre code').each(function(i, e) {hljs.highlightBlock(e)});
-             }, 'text');
-             $.get('raylib_text.c', function(data) {
-                 $('#text pre code').text(data);
-                 $('#text pre code').each(function(i, e) {hljs.highlightBlock(e)});
-             }, 'text');
-             $.get('raylib_models.c', function(data) {
-                 $('#models pre code').text(data);
-                 $('#models pre code').each(function(i, e) {hljs.highlightBlock(e)});
-             }, 'text');
-             $.get('raylib_audio.c', function(data) {
-                 $('#audio pre code').text(data);
-                 $('#audio pre code').each(function(i, e) {hljs.highlightBlock(e)});
-             }, 'text');
-             $.get('raylib_colors.c', function(data) {
-                 $('#colors pre code').text(data);
-                 $('#colors pre code').each(function(i, e) {hljs.highlightBlock(e)});
-             }, 'text');
-             $.get('raylib_structs.c', function(data) {
-                 $('#structs pre code').text(data);
-                 $('#structs pre code').each(function(i, e) {hljs.highlightBlock(e)});
+             $.get('raylib_math.c', function(data) {
+                 $('#math pre code').text(data);
+                 $('#math pre code').each(function(i, e) {hljs.highlightBlock(e)});
              }, 'text');
          });
         </script>
@@ -134,34 +92,13 @@
         </div>
         <br>
         <div id="fulldata">
-            <p id="pcore">module: rcore</p>
-            <div id="core"><pre><code class="cpp"></code></pre></div>
-            <p id="pshapes">module: rshapes</p>
-            <div id="shapes"><pre><code class="cpp"></code></pre></div>
-            <p id="ptextures">module: rtextures</p>
-            <div id="textures"><pre><code class="cpp"></code></pre></div>
-            <p id="ptext">module: rtext</p>
-            <div id="text"><pre><code class="cpp"></code></pre></div>
-            <p id="pmodels">module: rmodels</p>
-            <div id="models"><pre><code class="cpp"></code></pre></div>
-            <p id="paudio">module: raudio</p>
-            <div id="audio"><pre><code class="cpp"></code></pre></div>
-
-            <div id="fullgroup">
-                <div class="leftgroup">
-                    <p id="pstructs">structs</p>
-                    <div id="structs"><pre><code class="cpp"></code></pre></div>
-                </div>
-                <div class="rightgroup">
-                    <p id="pcolors">colors</p>
-                    <div id="colors"><pre><code class="cpp"></code></pre></div>
-                </div>
-            </div>
+            <p id="pmath">module: rmath</p>
+            <div id="math"><pre><code class="cpp"></code></pre></div>
 
             <p>Other cheatsheets</p>
             <ul>
                 <li>
-                    <a href="/cheatsheet/raymath_cheatsheet.html">raymath cheatsheet</a>
+                    <a href="/cheatsheet/cheatsheet.html" id="">raylib cheatsheet</a>
                 </li>
             </ul>
 
@@ -169,7 +106,6 @@
                 <p>raylib quick reference card - Copyright (c) 2013-2022 Ramon Santamaria (<a href="https://www.twitter.com/raysan5">@raysan5</a>)</p>
             </div>
         </div>
-
 
 
         <!-- Google Analytics tracking code -->


### PR DESCRIPTION
This PR adds a little python script that can generate the c files used for the cheatsheet, as well, it adds the math section to the cheatsheet. Attached is an image of what it generates. The output is a little different then what the cheatsheet used to show, as in some of the comments are slightly different, but this is because they are now the same as the comments in the header file.

I looked into using the existing raylib_parser, but using that there is no way to differentiate what section a function should belong to. That data could be added to the raylib parser, but I see no benefit to that except for the very specific use case of generating a cheatsheet. Seeing as the cheatsheet is just nicely formatted c files anyways. It made sense to me to have a specific tool to extract the desired c parts directly from the header files. If you think it's worth adding this extra information to the raylib_parser, I could do that then use that for this.

To use the python file, run `python3 generate_cheatsheet_code.py -r raylib/src/raylib.h -m raylib/src/raymath.h -o raylib.com/cheatsheet/` the raylib math file, or the raylib header are optional args and it will read from stdin if a filepath is not provided, same with the output file/directory. If not specified it will write to stdout so one can check what it will display. A single module can also be specified in which case it will output to a file instead of a directory. All this is explained when run with --help as well.

Anyways, let me know your thoughts on this.

![Screenshot 2022-08-22 at 16-15-24 raylib - cheatsheet](https://user-images.githubusercontent.com/3031097/186043082-bc1f2c51-d2e4-4ec5-90fb-fb7d34390393.png)
