### PR TITLE
Update Lua binding to a maintained LuaJIT binding

### DIFF
--- a/index.html
+++ b/index.html
@@ -121,7 +121,7 @@
                         <!--<a href="#"><img src="images/bindings/bind_cpp.png" title="windows" style="margin-right:8px;" alt="cpp raylib binding" width="84" height="84"/></a>-->
                         <a href="https://github.com/ChrisDill/Raylib-cs" target="_blank"><img class="icon" src="images/bindings/bind_csharp.png" title="raylib-cs" alt="c-sharp raylib binding" width="84" height="84"/></a>
                         <a href="https://github.com/gen2brain/raylib-go" target="_blank"><img class="icon" src="images/bindings/bind_go.png" title="raylib-go" alt="go raylib binding" width="84" height="84"/></a>
-                        <a href="https://github.com/Rabios/raylua" target="_blank"><img class="icon" src="images/bindings/bind_lua.png" title="raylib-lua" alt="lua raylib binding" width="84" height="84"/></a>
+                        <a href="https://github.com/tsnake41/raylib-lua" target="_blank"><img class="icon" src="images/bindings/bind_lua.png" title="raylib-lua" alt="lua raylib binding" width="84" height="84"/></a>
                         <a href="https://electronstudio.github.io/raylib-python-cffi/" target="_blank"><img class="icon" src="images/bindings/bind_python.png" title="raylib-py" alt="python raylib binding" width="84" height="84"/></a>
                         <a href="https://github.com/deltaphc/raylib-rs" target="_blank"><img class="icon" src="images/bindings/bind_rust.png" title="raylib-rs" alt="rust raylib binding" width="84" height="84"/></a>
                         <a href="https://github.com/Not-Nik/raylib-zig" target="_blank"><img class="icon" src="images/bindings/bind_zig.png" title="raylib-zig" alt="zig raylib binding" width="84" height="84"/></a>


### PR DESCRIPTION
Rabios binding is no longer updated, point instead to https://github.com/tsnake41/raylib-lua that is more active