### PR TITLE
Add a blurb to the homepage about the raylib-game-template

### DIFF
--- a/common/main.css
+++ b/common/main.css
@@ -582,6 +582,19 @@ li {
     margin-right: 2px;
 }
 
+a#game-template {
+    margin: 0 auto; 
+    border: 6px solid #888888; 
+    transition: all .2s ease; 
+    padding: 1em;
+    margin-bottom: 1em;
+}
+
+a#game-template:hover {
+    border: 6px solid #111111;
+    background-color: white;
+}
+
 #platforms>a>img {
     border: 6px solid #888888;
     transition: all .2s ease;

--- a/index.html
+++ b/index.html
@@ -84,6 +84,12 @@
                         <a href="https://github.com/raysan5/raylib-games" target="_blank"><img class="icon" src="images/learning/games.png" title="raylib games" alt="raylib games" width="112" height="112"/></a>
                     </div>
                 </div>
+                <p>Overwhelmed by the options? Maybe the raylib game template is a good place for you to start! It provides some structure and a Makefile that are quick and easy to pick up and use.</p>
+                <div style="display: flex;">
+                    <a href="https://github.com/raysan5/raylib-game-template" id="game-template">
+                        Try the raylib-game-template
+                    </a>
+                </div>
                 <p>Apart from those materials, there are plenty of tutorials created by the amazing raylib community. It's highly recommended to join the friendly <a href="https://discord.gg/raylib" target="_blank">raylib Discord Community</a> to stay up to date of latest raylib news and ask for help when required!</p>
                 <br>
                 <h2 id="awards"><a class="anchor-link" href="#awards"></a>raylib awards</h2>


### PR DESCRIPTION
This adds a short blurb as well as a prominent link to the raylib-game-template repo to encourage new users to try that out.  The link is in a style similar to other icons on the page with a 6px #888888 border that changes to #111111 on hover.