### PR TITLE
Typo fix in raylib_structs.c

### DIFF
--- a/cheatsheet/raylib_structs.c
+++ b/cheatsheet/raylib_structs.c
@@ -19,7 +19,7 @@
     struct Shader;                 // Shader
     struct MaterialMap;            // MaterialMap
     struct Material;               // Material, includes shader and maps
-    struct Transform;              // Transform, vectex transformation data
+    struct Transform;              // Transform, vertex transformation data
     struct BoneInfo;               // Bone, skeletal animation bone
     struct Model;                  // Model, meshes, materials and animation data
     struct ModelAnimation;         // ModelAnimation


### PR DESCRIPTION
Found a typo in the cheatsheet and wanted to fix it. My only question is how do I regenerate the .pdf? The tool in cheatsheet/tool/generate_cheatsheet_code.py only regenerates the .c files, not the pdf :(