### PR TITLE
Fix: add `simplelink` class to hidden links on home page

### DIFF
--- a/index.html
+++ b/index.html
@@ -94,7 +94,7 @@
                         Try the raylib-game-template
                     </a>
                 </div>
-                <p>Apart from those materials, there are plenty of tutorials created by the amazing raylib community. It's highly recommended to join the friendly <a href="https://discord.gg/raylib" target="_blank">raylib Discord Community</a> to stay up to date of latest raylib news and ask for help when required!</p>
+                <p>Apart from those materials, there are plenty of tutorials created by the amazing raylib community. It's highly recommended to join the friendly <a class="simplelink" href="https://discord.gg/raylib" target="_blank">raylib Discord Community</a> to stay up to date of latest raylib news and ask for help when required!</p>
                 <br>
                 <h2 id="awards"><a class="anchor-link" href="#awards"></a>raylib awards</h2>
                 <br>
@@ -127,7 +127,7 @@
                 <br>
                 <h2 id="bindings"><a class="anchor-link" href="#bindings"></a>raylib language bindings</h2>
                 <br>
-                <p>You can use raylib with multiple programming languages, there are <a href="https://github.com/raysan5/raylib/blob/master/BINDINGS.md" target="_blank">+60 bindings</a>! Here is a list with some of them:</p>
+                <p>You can use raylib with multiple programming languages, there are <a class="simplelink" href="https://github.com/raysan5/raylib/blob/master/BINDINGS.md" target="_blank">+60 bindings</a>! Here is a list with some of them:</p>
                 <br>
                 <div style="display: flex;">
                     <div id="bindings" style="margin: 0 auto;">


### PR DESCRIPTION
On the home page of [raylib.com](https://raylib.com) the link to `raylib Discord Community` and a link to the `60+ bindings` are unstyled, so you only know they are links when you hover over them.

This PR  adds the `simplelink` class to these links to make them consistent with the other inline links on the page.