### PR TITLE
fix 1px of white underneath active header item

### DIFF
--- a/common/main.css
+++ b/common/main.css
@@ -264,7 +264,7 @@ li {
     position: relative;
 
     border: 2px solid #c8c8c8;
-    border-bottom: none;
+    border-bottom-color: #5050;
 }
 
 .menu a:hover,


### PR DESCRIPTION
The active header item has 1 pixel of white underneath it(see below the "about" button in the header):

![2024-09-09-11:13:04](https://github.com/user-attachments/assets/a9287bf5-3af4-4a01-a82a-557b800ba6f1)

This can be fixed with a 1 line change in the CSS:

![2024-09-09-11:15:10](https://github.com/user-attachments/assets/aba94f14-6295-4241-8965-1e7c8d51e95b)
