### PR TITLE
Mobile Responsiveness Update

### DIFF
--- a/common/examples.css
+++ b/common/examples.css
@@ -1,10 +1,25 @@
+#container{
+    display: flex;
+    gap: 10px;
+    flex-wrap: wrap;
+    justify-content: center;
+    margin-bottom: 10px;
+    @media screen and (width <= 730px){
+        max-width: var(--content-width);     
+        overflow-x: hidden;
+    }
+}
 #container .mix{ position: relative;  display: none; }
 #container .extext { top: 160px!important; width: 400px!important; }
 #difficulty_level { position: absolute; bottom: 18px; left: 12px; font-size: 24px; }
+#filter-input-element{
+     padding-left: 10px; padding-block: 5px; color: rgb(0, 0, 0); 
 
-#filter_menu { width:820px; height:80px; margin-left:15px; }
-#filter_function_label { margin-top: 2rem; }
-#filter_function { display: block; height: 1rem; margin-left:15px; margin-bottom: 2rem; }
+    }
+.filter_centered_label { margin-inline: auto; text-align: center; margin-top: 1rem; }
+#filter_menu{display:flex;flex-wrap:wrap;justify-content:center}
+#filter_function_label { margin-inline: auto; text-align: center; margin-top: 1rem; }
+#filter_function { display: flex; margin-inline: auto; flex-direction: column; margin-bottom: 2rem; }
 #matches_counter { display: inline; margin-bottom: 2rem; }
 
 .legendButton { float:left; margin-right:8px; margin-bottom:20px; width:84px; height:78px; text-align:right; line-height:130px; cursor: pointer; transition: 0.125s; }
@@ -19,13 +34,13 @@
 
 .legendButton:hover { border: 5px solid #000 !important; }
 
-.fcore { border: 1px solid #898888; margin-left: 12px; }
-.fshapes { border: 1px solid #e66666; margin-left: 12px; }
-.ftextures { border: 1px solid #75a06d; margin-left: 12px; }
-.ftext { border: 1px solid #52b296; margin-left: 12px; }
-.fmodels { border: 1px solid #5d9cbd; margin-left: 12px; }
-.fshaders { border: 1px solid #a864d2; margin-left: 12px; }
-.faudio { border: 1px solid #d3b157; margin-left: 12px; }
+.fcore { border: 1px solid #898888;  }
+.fshapes { border: 1px solid #e66666;}
+.ftextures { border: 1px solid #75a06d; }
+.ftext { border: 1px solid #52b296; }
+.fmodels { border: 1px solid #5d9cbd;}
+.fshaders { border: 1px solid #a864d2;  }
+.faudio { border: 1px solid #d3b157; }
 .fphysics { border: 1px solid #00a820; margin-left: 12px; }
 
 .fcore p { color:#5c5a5a!important; }

--- a/common/games.css
+++ b/common/games.css
@@ -1,9 +1,30 @@
+#container{
+    display: flex;
+    gap: 10px;
+    flex-wrap: wrap;
+    justify-content: center;
+    margin-bottom: 10px;
+    max-width: max-content;
+    @media screen and (width <= 730px){
+        max-width: 100%;     
+        overflow-x: hidden;
+    }
+}
+
+.page{
+   display: flex;
+   flex-direction: column;
+   align-content: center;
+   justify-content: center;
+}
+.intro-text{  margin-inline: auto; text-align: center; margin-top: 1rem;}
+
 #container .mix{ position: relative;  display: none; }
 #container .extext { top: 160px!important; width: 400px!important; }
 
-#filter_menu { width: 820px; height: 80px; margin-left: 2px; }
+#filter_menu { display: flex; gap: 10px; flex-wrap: wrap; justify-content: center; justify-items: center; margin-inline: auto; margin-bottom: 15px; }
 
-.legendButton { padding:5px 15px; float:left; margin-left:10px; margin-right:10px; margin-bottom:20px; width:150px; text-align:center; }
+.legendButton { padding:5px 15px; float:left;  width:150px; text-align:center; }
 #classic { cursor:pointer; background-color:#e1e1e1; color:#5c5a5a; border:3px solid #898888; }
 #game { cursor:pointer; background-color:#f0d6d6; color:#c55757; border:3px solid #e66666; }
 

--- a/common/main.css
+++ b/common/main.css
@@ -47,7 +47,7 @@
 }
 
 html {
-    scroll-behavior: smooth;
+    scroll-behavior: smooth;    
 }
 
 body {
@@ -88,7 +88,8 @@ h2::before {
 }
 
 .page {
-    width: min(var(--content-width), 100vw);
+    max-width: var(--content-width); 
+    /* width: 100%; */
     min-height: fit-content;
     margin: 0 auto;
     padding-top: 128px;
@@ -101,19 +102,16 @@ h2::before {
 }
 
 .header-container {
+    /* width: max(100%, var(--content-width)); */
+    width: 100dvw;
     position: fixed;
-    top: 0px;
-    left: 0px;
-
-    width: max(100%, var(--content-width));
+    /* top: 0px;
+    left: 0px; */
     display: flex;
     flex-direction: row;
     justify-content: center;
-
     background-color: white;
-
     border-bottom: 2px solid #8c8c8c;
-
     z-index: 100;
 }
 
@@ -130,9 +128,11 @@ h2::before {
 }
 
 .content {
+    display: flex;
+    flex-direction: column;
     font-size: 8pt;
     padding-top: 30px;
-    float: left;
+    /* float: left; */
     position: relative;
 }
 
@@ -641,23 +641,12 @@ a#game-template:hover {
 
 /* GotoTopButton css */
 @keyframes springAnim{
-    0%{
-        transform: scale(0);
-    }
-    30%{
-        transform: scale(1.8);
-    }
-    50%{
-        transform: scale(0.9);
-    }
-
-    100%{
-        transform: scale(1);
-    }
+    0%{transform:scale(0)}
+    30%{transform:scale(1.8)}
+    50%{transform:scale(.9)}
+    100%{transform:scale(1)}
 }
-.spring-anim-class{
-    animation: springAnim 0.6s forwards;
-}
+.spring-anim-class{animation:springAnim .6s forwards}
 .go-to-top-button{
     display: none;
     position: fixed;
@@ -671,7 +660,32 @@ a#game-template:hover {
 }
 .go-to-top-button:hover{cursor:pointer}
 @media print{.back-to-top-arrow{display:none}}
-@media only screen and (max-width: 600px) {
+/* Mobile Menu */
+.nav-mobile-container{display:none}
+#hamburger-button{    
+    --max-button-size: 60px;
+    display: flex;
+    margin-left: auto;
+    margin-right: 5%;
+    position: relative;
+    max-height: var(--max-button-size);
+    max-width: var(--max-button-size);
+    border: none;
+    background-color: transparent;
+    padding: 10px;
+    &:hover{
+        cursor: pointer;
+        color: white;
+        background-color: #111111;
+    }
+}
+@media only screen and (width > 730px){
+    #hamburger-button{
+        display: none;        
+    }    
+}
+
+@media only screen and (max-width: 730px) {
 
     /* general layout changes for mobile */
     ul {
@@ -697,6 +711,7 @@ a#game-template:hover {
     .header {
         display: flex;
         width: 100vw;
+        align-items: center;
         -ms-overflow-style: none;  /* Internet Explorer 10+ */
         scrollbar-width: none;  /* Firefox */
     }
@@ -717,8 +732,82 @@ a#game-template:hover {
         flex-direction: column; 
         flex-shrink: 0;
     }
-    /* This is where the logic for the mobile navbar will be */
-    /* .nav-container{
+    /* Mobile menu css logic */
+    .nav-container{
         display: none;
-    } */
+    }
+    #hamburger-button{
+        display: flex;    
+        background-color: transparent;
+    }
+    
+    .nav-mobile-container[data-open="true"] {
+        display: flex;
+        position: fixed;   
+        top: 0;
+        left: 0;
+        flex-direction: column;
+        width: 100%;  
+        height: 100%;
+        z-index: 200;
+        background-color: white;
+    }
+    #mobile-title-bar{
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        margin-inline: 20px;
+    }
+    #mobile-close-button{
+        --button-size: 40px;
+        display: flex;
+        width: var(--button-size);
+        height: var(--button-size);
+        border: none;
+        background-color: transparent;
+        margin-right: 2%;
+        padding: 5px;
+        &:hover{cursor:pointer}
+    }
+    #mobile-social{
+        display: flex;
+        position: relative;
+        flex-wrap: wrap;
+        margin-inline-start: 25px;
+        margin-top: 60px;
+        width: 60%;
+        height: fit-content;
+        --icons-size: 36px;
+        gap: 10px;
+        a{
+            display: flex;
+            width: var(--icons-size);
+            height: var(--icons-size);
+            img{
+                position: absolute;
+                clip: rect(0px, var(--icons-size), var(--icons-size), 0px);
+            }            
+        }       
+    }
+
+    .header-container{
+        
+        align-items: center;
+        min-width: 210px;
+    }
+    .mobile-menu{
+        display: flex;
+        flex-direction: column;
+        > a{
+            padding-inline-start: 20px;
+            padding-block: 20px;
+            &:not(.mobile-active){color:#5c5a5a}
+        }
+        
+    }
+    .mobile-active{
+        color: rgb(0, 0, 0);
+        border-block: 2px solid #5c5a5a;
+        background-color: #cecece;
+    }
 }

--- a/examples.html
+++ b/examples.html
@@ -66,8 +66,8 @@
             <![endif]-->
 
             <div class="content">
-                <p>raylib examples are organized by colors depending on the raylib module they focus.</p>
-                <p>Click on the module to filter examples:</p>
+                <p>raylib examples are organized by colors depending on the raylib module they focus on.</p>
+                <p class="filter_centered_label">Click on the module to filter examples:</p>
                 <br>
 
                 <!--<div class="filter legendButton" data-filter="all">ALL</div> -->
@@ -83,7 +83,7 @@
 
                 <p id="filter_function_label">Or filter by used functions in the example:</p>
                 <div id="filter_function">
-                    <input></input>
+                    <input id="filter-input-element" placeholder="e.i function name">
                     <p id="matches_counter"></p>
                 </div>
                 

--- a/games.html
+++ b/games.html
@@ -66,7 +66,7 @@
             <![endif]-->
 
             <div class="content">
-                <p>raylib games are organized in two categories:</p>
+                <p class="intro-text">raylib games are organized in two categories:</p>
                 <br>
                 <div id="filter_menu">
                     <div class="filter legendButton" id="classic" data-filter=".fclassic">classic games</div>

--- a/ui_manager.js
+++ b/ui_manager.js
@@ -7,8 +7,101 @@ const htmlGoToTopButton = `
         </svg>
     </a>
 `
+const htmlHamburgerButton = `<button id="hamburger-button"></button>`
+const svgHamburgerMenu = `
+<svg  width="100%" height="100%" viewBox="0 0 242 181" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xml:space="preserve" xmlns:serif="http://www.serif.com/" style="fill-rule:evenodd;clip-rule:evenodd;stroke-linejoin:round;stroke-miterlimit:2;"><g id="hamburger"><path d="M241.667,20.885c-0,11.526 -9.358,20.885 -20.885,20.885l-199.897,-0c-11.527,-0 -20.885,-9.359 -20.885,-20.885c0,-11.527 9.358,-20.885 20.885,-20.885l199.897,0c11.527,0 20.885,9.358 20.885,20.885Z" style="fill:currentColor;"/><path d="M241.667,90.306c-0,11.527 -9.358,20.885 -20.885,20.885l-199.897,-0c-11.527,-0 -20.885,-9.358 -20.885,-20.885c0,-11.527 9.358,-20.885 20.885,-20.885l199.897,0c11.527,0 20.885,9.358 20.885,20.885Z" style="fill:currentColor;"/><path d="M241.667,159.727c-0,11.527 -9.358,20.885 -20.885,20.885l-199.897,-0c-11.527,-0 -20.885,-9.358 -20.885,-20.885c0,-11.527 9.358,-20.885 20.885,-20.885l199.897,0c11.527,0 20.885,9.358 20.885,20.885Z" style="fill:currentColor;"/></g></svg>`
 const body = document.body
+const headerElement = document.querySelector(".header")
+headerElement.insertAdjacentHTML("beforeend", htmlHamburgerButton)
+const hamburgerButton = document.querySelector("#hamburger-button")
+hamburgerButton.insertAdjacentHTML("beforeend", svgHamburgerMenu)
 body.insertAdjacentHTML("afterbegin", htmlGoToTopButton)
+const currentPage = window.location.pathname 
+let mobileActive = "" 
+const activeMobileElement = {
+    aboutInactive: `<a id="mobile-about" href="index.html" >about</a>`,
+    examplesInactive: `<a id="mobile-examples" href="examples.html">examples</a>`,
+    gamesInactive: `<a id="mobile-games" href="games.html">games</a>`,
+
+    activeAbout: `<a id="mobile-about" class="mobile-active">about</a>`,
+    activeExamples: `<a id="mobile-examples" class="mobile-active" >examples</a>`,
+    activeGames: `<a id="mobile-games" class="mobile-active" >games</a>`,
+    about: ``,
+    examples: ``, 
+    games: ``, 
+    setPage(page){
+        switch(page){
+            case "/index.html":
+                 this.about = this.activeAbout
+                 this.games = this.gamesInactive
+                 this.examples = this.examplesInactive
+            break;
+            case "/examples.html":
+                this.about = this.aboutInactive
+                this.games = this.gamesInactive
+                this.examples = this.activeExamples
+            break;
+            case "/games.html":
+                this.about = this.aboutInactive
+                this.games = this.activeGames
+                this.examples = this.examplesInactive
+            break;
+        }
+    }
+}
+activeMobileElement.setPage(currentPage)
+const mobileMenu = `
+<div class="nav-mobile-container" data-open="false">
+        <div id="mobile-title-bar">
+                <div id="mobile-logo">
+                        <img src="common/img/raylib_logo.png" alt="">
+                </div>
+                <button id="mobile-close-button"></button>
+        </div>
+        <nav class="mobile-menu">
+                ${activeMobileElement.about}
+                ${activeMobileElement.examples}
+                ${activeMobileElement.games}
+                <a id= "mobile-cheatsheet" href="cheatsheet/cheatsheet.html">cheatsheet</a>
+                <a id="mobile-wiki"href="https://github.com/raysan5/raylib/wiki" target="_blank">wiki</a>
+        </nav>
+        <div id="mobile-social"></div>
+</div>
+`
+body.insertAdjacentHTML("afterbegin", mobileMenu)
+const svgCloseButton = `
+<svg width="100%" height="100%" viewBox="0 0 168 168" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xml:space="preserve" xmlns:serif="http://www.serif.com/" style="fill-rule:evenodd;clip-rule:evenodd;stroke-linejoin:round;stroke-miterlimit:2;"><rect id="mobile-menu-1" serif:id="mobile menu 1" x="-3078.56" y="-212.563" width="3508.33" height="6633.33" style="fill:none;"/><clip-path id="_clip1"><rect x="-3078.56" y="-212.563" width="3508.33" height="6633.33"/></clip-path><g clip-path="url(#_clip1)"><g id="mobile-nav" serif:id="mobile nav"><g class="hamburger-piece"><path d="M171.441,-21.568c0,11.527 -9.358,20.885 -20.884,20.885l-199.898,0c-11.526,0 -20.884,-9.358 -20.884,-20.885c-0,-11.526 9.358,-20.884 20.884,-20.884l199.898,-0c11.526,-0 20.884,9.358 20.884,20.884Z" style="fill:#727272;"/><path d="M171.441,35.354c0,11.526 -9.358,20.884 -20.884,20.884l-199.898,0c-11.526,0 -20.884,-9.358 -20.884,-20.884c-0,-11.527 9.358,-20.885 20.884,-20.885l199.898,-0c11.526,-0 20.884,9.358 20.884,20.885Z" style="fill:#727272;"/><path d="M171.441,92.275c0,11.526 -9.358,20.884 -20.884,20.884l-199.898,0c-11.526,0 -20.884,-9.358 -20.884,-20.884c-0,-11.527 9.358,-20.885 20.884,-20.885l199.898,-0c11.526,-0 20.884,9.358 20.884,20.885Z" style="fill:#727272;"/></g></g><g id="mobile-menu" serif:id="mobile menu"><rect x="-3095.22" y="-212.563" width="3529.17" height="6633.33" style="fill:#fff;"/><g id="x"><path d="M162.278,5.605c7.473,7.472 7.473,19.606 0,27.079l-129.594,129.594c-7.473,7.473 -19.607,7.473 -27.079,0c-7.473,-7.473 -7.473,-19.606 -0,-27.079l129.594,-129.594c7.473,-7.473 19.606,-7.473 27.079,-0Z" style="fill:#727272;"/><path d="M162.278,162.278c-7.473,7.473 -19.606,7.473 -27.079,0l-129.594,-129.594c-7.473,-7.473 -7.473,-19.607 -0,-27.079c7.472,-7.473 19.606,-7.473 27.079,-0l129.594,129.594c7.473,7.473 7.473,19.606 0,27.079Z" style="fill:#727272;"/></g></g></g></svg>
+`;
+const mobileCloseButton = document.querySelector("#mobile-close-button");
+mobileCloseButton.insertAdjacentHTML("beforeend", svgCloseButton);
+mobileCloseButton.addEventListener("click", disableHamburgerNavBar);
+hamburgerButton.addEventListener("click", enableHamburgerNavBar);
+const mobileSocialsContainer = document.querySelector("#mobile-social");
+const mobileNavBar = document.querySelector(".nav-mobile-container")
+
+mobileSocialsContainer.insertAdjacentHTML("beforeend",
+    `<a id="mobile-twitter" href="https://www.twitter.com/raysan5" target="_blank" aria-label="raysan5's Twitter"><img src="common/img/icon_twitter.png" /></a>
+    <a id="mobile-discord" href="https://discord.gg/raylib" target="_blank" aria-label="raylib discord"><img src="common/img/icon_discord.png" ></a>
+    <a id="mobile-twitch" href="https://www.twitch.tv/raysan5" target="_blank" aria-label="raysan5 twitch channel"><img src="common/img/icon_twitch.png" /></a>
+    <a id="mobile-kofi" href="https://ko-fi.com/raysan5" target="_blank" aria-label="raylib coffee page for support"><img src="common/img/icon_kofi.png" /></a>
+    <a id="mobile-itchio" href="https://raysan5.itch.io" target="_blank" aria-label="raylib itch.io page"><img src="common/img/icon_itchio.png" ></a>
+    <a id="mobile-handmade" href="https://raylib.handmade.network/" target="_blank" aria-label="raylib handmadenetwork"><img src="common/img/icon_handmade.png" /></a>
+    <a id="mobile-reddit" href="https://www.reddit.com/r/raylib/" target="_blank" aria-label="raylib reddit"><img src ="common/img/icon_reddit.png"/></a>
+    <a id="mobile-youtube" href="https://www.youtube.com/c/raylib" target="_blank" aria-label="raylib youtube channel"><img src="common/img/icon_youtube.png" /></a>
+    <a id="mobile-patreon" href="https://www.patreon.com/raylib" target="_blank" aria-label="ray's patreon page"><img src="common/img/icon_patreon.png" /></a>
+    <a id="mobile-redbubble" href="https://www.redbubble.com/shop/ap/78130012" target="_blank" aria-label="red bubble"><img src="common/img/icon_redbubble.png" /></a>
+    <a id="mobile-github" href="https://github.com/raysan5/raylib" target="_blank" aria-label="raylib's github"><img src="common/img/icon_github.png" /></a>`
+);
+function enableHamburgerNavBar(){
+    mobileNavBar.setAttribute("data-open", "true");
+    body.style.height = "100%"
+    body.style.overflowY = "hidden"
+}
+function disableHamburgerNavBar(){    
+    mobileNavBar.setAttribute("data-open", "false");
+    body.style.height = "unset"
+    body.style.overflowY = "unset"
+}
 
 const goToTopButton = document.querySelector(".go-to-top-button");
 window.addEventListener("scroll", toggleGoToTopButton);


### PR DESCRIPTION
### **This update highlights a good amount of fixes related to horizontal overflow. This caused issues when it came to implementing mobile responsiveness.**

What has changed:

-Fixed a typo on the examples page. It said the raylib module they focus, so I added the **on** at the end of focus. 

-A mobile menu is fully accessible from pages _about_, _examples_, and _games_ for now. 

-All svgs and html that would require to be duplicated across all three pages _about_, _examples_, and _games_, are now dynamically added from the ui_manager.js file.

-There's a hamburger menu that users can access on mobile, tablet or when the window becomes smaller horizontally on desktop.

-Scrolling is now disabled when the hamburger menu is on, and disabled when off.

-I've also modified  some classes in order to make sure there are no inconsistencies in size when viewing the game examples. This needs to be further modified in order to update the styling on mobile.

-All social media buttons for the mobile menu have been improved to include some accessibility features like being able to be recognized by screen readers. 

-The input box has been further improved to display some place holder text, and to be centered only occupying space based on its length. It has also been centered to make better use of space. The same thing was done for its label. elements that work together need to be closer together to prevent confusion.

![image](https://github.com/user-attachments/assets/b4ec7bf2-aa61-47d3-8597-390e58c513af)

![WhatsApp Image 2024-09-14 at 05 40 07_4dfd9dba](https://github.com/user-attachments/assets/57b1eccc-6a05-4c02-9f80-676a02448010)

![WhatsApp Image 2024-09-14 at 05 40 07_625a0ece](https://github.com/user-attachments/assets/0f7b19df-ad25-4812-bacb-59b038f3563f)

mobile menu:
![WhatsApp Image 2024-09-14 at 05 41 44_62bb3b1f](https://github.com/user-attachments/assets/f95a9593-fbdd-46bc-ac47-e54f0e1504ee)

