### PR TITLE
[examples] enhance searching with tags

### DIFF
--- a/examples/examples_tags.json
+++ b/examples/examples_tags.json
@@ -1,0 +1,5 @@
+{
+	"core_basic_window": ["window"],
+	"core_basic_screen_manager": ["screen", "scene"],
+	"core_2d_camera": ["2d", "camera", "zoom"]
+}


### PR DESCRIPTION
### Making this PR to see what you think of the concept before i populate the JSON further

This does **NOT** affect the existing search method. **It enhances (adds) to it only.**

**example:** if a user is trying to find how to "change scenes" or use a "render texture", no results will come up because of the way the search currently works. But by adding tags, we can optionally add new terms to specific examples and make it easier to search.

Another reason is that some examples may show various functionality but the name will not reflect that

**If an entry is not added to `examples_tags.json` then it will work exactly how it did before. they only add to the search results. This means that we do not need to populate the JSON (or add an entry for new examples) but can do so over time**