### PR TITLE
Added tabs for displaying shader code in examples

### DIFF
--- a/examples/core/loader.html
+++ b/examples/core/loader.html
@@ -112,7 +112,7 @@
                             )
                         );
                         
-						// Hardcoding glsl version for now
+                        // Hardcoding glsl version for now
                         const glslVersion = "330";
                         
                         $.get(shaderBaseUrl + shaderUriPattern.replace('%i', glslVersion), function(code) {

--- a/examples/core/loader.html
+++ b/examples/core/loader.html
@@ -49,6 +49,16 @@
             .fancybox-wrap fancybox-desktop fancybox-type-iframe fancybox-opened { width: 860px!important;}
             .fancybox-inner { width: 850px!important; }
             .fancybox-iframe { width: 830px!important; }
+            
+            .tab-content > div { display: none; }
+            .tab-content > div.active { display: block; }
+            .tab-content > div pre { margin-top: 0!important; }
+            
+            .nav-tabs { display: block; padding: 0; margin: 10px 0 0 0; list-style: none; font-family: Courier New, Verdana, Arial !important; font-size: small; }
+            .nav-tabs li { position: relative; top: 1px; display: inline-block; margin: 5px 5px 0 5px; padding: 5px; border: 1px solid #b0b0b0; background: white; }
+            .nav-tabs li.active { border-bottom-color: #f0f0f0; background: #f0f0f0; }
+            .nav-tabs li a { text-decoration: none; color: #b0b0b0; }
+            .nav-tabs li.active a { text-decoration: none; color: black; }
         </style>
 
         <script type="text/javascript">
@@ -73,15 +83,56 @@
                 var srcUrl = 'https://raw.githubusercontent.com/raysan5/raylib/master/examples/' + type + '/' + name + '.c';
                 var imgUrl = 'https://raw.githubusercontent.com/raysan5/raylib/master/examples/' + type + '/' + name + '.png';
                 var linkUrl = 'https://github.com/raysan5/raylib/blob/master/examples/' + type + '/' + name + '.c';
+                var shaderBaseUrl = 'https://raw.githubusercontent.com/raysan5/raylib/master/examples/' + type + '/';
 
                 $('#eximage img').attr('src', imgUrl);
 
                 $.get(srcUrl, function(data)
                 {
-                    $('pre code').text(data);
-                    $('pre code').each(function(i, e) {hljs.highlightBlock(e)});
-
+                    $('pre.main_source code').text(data);
+                    $('pre.main_source code').each(function(i, e) {hljs.highlightBlock(e)});
+                    
                     $('#source_link').attr("href", linkUrl);
+                    
+                    $('.nav-tabs a[href="#main_source"]').text(name + ".c");
+                    
+                    data.matchAll(/TextFormat\("(resources\/(?:[-_a-zA-Z0-9]+\/)*((?:[-_a-zA-Z0-9]+%i|glsl%i\/[-_a-zA-Z0-9]+)\.[fv]s))", GLSL_VERSION\)/g).forEach(function(match, index) {
+                        const shaderUriPattern = match[1];
+                        const shaderName = match[2].replace(/(\/?glsl)?%i/, '').replace(/^\//, ''); // Strip off versions here
+                        const shaderTabId = 'shader_' + (1+index);
+                        
+                        $('.nav-tabs').append(
+                            $('<li><a href="#'+shaderTabId+'">' + shaderName + '</a></li>')
+                        );
+                        
+                        const newCodePanel = $('<code class="glsl"></code>');
+                        $('.tab-content').append(
+                            $('<div id="' + shaderTabId + '"></div>').append(
+                                $('<pre></pre>').append(newCodePanel)
+                            )
+                        );
+                        
+						// Hardcoding glsl version for now
+                        const glslVersion = "330";
+                        
+                        $.get(shaderBaseUrl + shaderUriPattern.replace('%i', glslVersion), function(code) {
+                            newCodePanel.text(code);
+                            newCodePanel.each(function(i, e) {hljs.highlightBlock(e)});
+                        }, 'text');
+                    });
+                    
+
+                    $(".nav-tabs a").click(function(e){
+                        e.preventDefault();
+                        
+                        const paneToActivate = $(this.hash);
+                        $('.tab-content > div.active').removeClass('active');
+                        $('.nav-tabs > li.active').removeClass('active');
+                        
+                        $(this).parent('li').addClass('active');
+                        paneToActivate.addClass('active');
+                    });
+                    
                 }, 'text');
 
                 // Quick hack for some examples not working on web
@@ -136,9 +187,18 @@
         <div id="eximage"></div>
 
         <!--<textarea id="output" rows="8"></textarea>-->
-
-        <pre><code class="cpp"></code></pre>
-
+        
+        <ul class="nav-tabs">
+            <li class="active"><a href="#main_source">Main Source</a></li>
+        </ul>
+        
+        <div class="tab-content">
+            <div id="main_source" class="tab-pane active">
+                <pre class="main_source"><code class="cpp"></code></pre>
+            </div>
+        </div>
+        
+        
         <p>raylib example <a id="source_link" href="" target="_blank">source code</a></p>
 
         <script type='text/javascript'>

--- a/examples/models/loader.html
+++ b/examples/models/loader.html
@@ -112,7 +112,7 @@
                             )
                         );
                         
-						// Hardcoding glsl version for now
+                        // Hardcoding glsl version for now
                         const glslVersion = "330";
                         
                         $.get(shaderBaseUrl + shaderUriPattern.replace('%i', glslVersion), function(code) {

--- a/examples/models/loader.html
+++ b/examples/models/loader.html
@@ -49,6 +49,16 @@
             .fancybox-wrap fancybox-desktop fancybox-type-iframe fancybox-opened { width: 860px!important;}
             .fancybox-inner { width: 850px!important; }
             .fancybox-iframe { width: 830px!important; }
+            
+            .tab-content > div { display: none; }
+            .tab-content > div.active { display: block; }
+            .tab-content > div pre { margin-top: 0!important; }
+            
+            .nav-tabs { display: block; padding: 0; margin: 10px 0 0 0; list-style: none; font-family: Courier New, Verdana, Arial !important; font-size: small; }
+            .nav-tabs li { position: relative; top: 1px; display: inline-block; margin: 5px 5px 0 5px; padding: 5px; border: 1px solid #b0b0b0; background: white; }
+            .nav-tabs li.active { border-bottom-color: #f0f0f0; background: #f0f0f0; }
+            .nav-tabs li a { text-decoration: none; color: #b0b0b0; }
+            .nav-tabs li.active a { text-decoration: none; color: black; }
         </style>
         
         <script type="text/javascript">
@@ -73,15 +83,56 @@
                 var srcUrl = 'https://raw.githubusercontent.com/raysan5/raylib/master/examples/' + type + '/' + name + '.c';
                 var imgUrl = 'https://raw.githubusercontent.com/raysan5/raylib/master/examples/' + type + '/' + name + '.png';
                 var linkUrl = 'https://github.com/raysan5/raylib/blob/master/examples/' + type + '/' + name + '.c';
+                var shaderBaseUrl = 'https://raw.githubusercontent.com/raysan5/raylib/master/examples/' + type + '/';
 
                 $('#eximage img').attr('src', imgUrl);
 
                 $.get(srcUrl, function(data)
-                { 
-                    $('pre code').text(data);
-                    $('pre code').each(function(i, e) {hljs.highlightBlock(e)});
+                {
+                    $('pre.main_source code').text(data);
+                    $('pre.main_source code').each(function(i, e) {hljs.highlightBlock(e)});
                     
                     $('#source_link').attr("href", linkUrl);
+                    
+                    $('.nav-tabs a[href="#main_source"]').text(name + ".c");
+                    
+                    data.matchAll(/TextFormat\("(resources\/(?:[-_a-zA-Z0-9]+\/)*((?:[-_a-zA-Z0-9]+%i|glsl%i\/[-_a-zA-Z0-9]+)\.[fv]s))", GLSL_VERSION\)/g).forEach(function(match, index) {
+                        const shaderUriPattern = match[1];
+                        const shaderName = match[2].replace(/(\/?glsl)?%i/, '').replace(/^\//, ''); // Strip off versions here
+                        const shaderTabId = 'shader_' + (1+index);
+                        
+                        $('.nav-tabs').append(
+                            $('<li><a href="#'+shaderTabId+'">' + shaderName + '</a></li>')
+                        );
+                        
+                        const newCodePanel = $('<code class="glsl"></code>');
+                        $('.tab-content').append(
+                            $('<div id="' + shaderTabId + '"></div>').append(
+                                $('<pre></pre>').append(newCodePanel)
+                            )
+                        );
+                        
+						// Hardcoding glsl version for now
+                        const glslVersion = "330";
+                        
+                        $.get(shaderBaseUrl + shaderUriPattern.replace('%i', glslVersion), function(code) {
+                            newCodePanel.text(code);
+                            newCodePanel.each(function(i, e) {hljs.highlightBlock(e)});
+                        }, 'text');
+                    });
+                    
+
+                    $(".nav-tabs a").click(function(e){
+                        e.preventDefault();
+                        
+                        const paneToActivate = $(this.hash);
+                        $('.tab-content > div.active').removeClass('active');
+                        $('.nav-tabs > li.active').removeClass('active');
+                        
+                        $(this).parent('li').addClass('active');
+                        paneToActivate.addClass('active');
+                    });
+                    
                 }, 'text');
                 
                 // Quick hack for some examples not working on web
@@ -137,7 +188,15 @@
         
         <!--<textarea id="output" rows="8"></textarea>-->
         
-        <pre><code class="cpp"></code></pre>
+        <ul class="nav-tabs">
+            <li class="active"><a href="#main_source">Main Source</a></li>
+        </ul>
+        
+        <div class="tab-content">
+            <div id="main_source" class="tab-pane active">
+                <pre class="main_source"><code class="cpp"></code></pre>
+            </div>
+        </div>
         
         <p>raylib example <a id="source_link" href="" target="_blank">source code</a></p>
 

--- a/examples/shaders/loader.html
+++ b/examples/shaders/loader.html
@@ -112,7 +112,7 @@
                             )
                         );
                         
-						// Hardcoding glsl version for now
+                        // Hardcoding glsl version for now
                         const glslVersion = "330";
                         
                         $.get(shaderBaseUrl + shaderUriPattern.replace('%i', glslVersion), function(code) {

--- a/examples/shaders/loader.html
+++ b/examples/shaders/loader.html
@@ -49,6 +49,16 @@
             .fancybox-wrap fancybox-desktop fancybox-type-iframe fancybox-opened { width: 860px!important;}
             .fancybox-inner { width: 850px!important; }
             .fancybox-iframe { width: 830px!important; }
+            
+            .tab-content > div { display: none; }
+            .tab-content > div.active { display: block; }
+            .tab-content > div pre { margin-top: 0!important; }
+            
+            .nav-tabs { display: block; padding: 0; margin: 10px 0 0 0; list-style: none; font-family: Courier New, Verdana, Arial !important; font-size: small; }
+            .nav-tabs li { position: relative; top: 1px; display: inline-block; margin: 5px 5px 0 5px; padding: 5px; border: 1px solid #b0b0b0; background: white; }
+            .nav-tabs li.active { border-bottom-color: #f0f0f0; background: #f0f0f0; }
+            .nav-tabs li a { text-decoration: none; color: #b0b0b0; }
+            .nav-tabs li.active a { text-decoration: none; color: black; }
         </style>
         
         <script type="text/javascript">
@@ -73,15 +83,56 @@
                 var srcUrl = 'https://raw.githubusercontent.com/raysan5/raylib/master/examples/' + type + '/' + name + '.c';
                 var imgUrl = 'https://raw.githubusercontent.com/raysan5/raylib/master/examples/' + type + '/' + name + '.png';
                 var linkUrl = 'https://github.com/raysan5/raylib/blob/master/examples/' + type + '/' + name + '.c';
+                var shaderBaseUrl = 'https://raw.githubusercontent.com/raysan5/raylib/master/examples/' + type + '/';
 
                 $('#eximage img').attr('src', imgUrl);
 
                 $.get(srcUrl, function(data)
-                { 
-                    $('pre code').text(data);
-                    $('pre code').each(function(i, e) {hljs.highlightBlock(e)});
+                {
+                    $('pre.main_source code').text(data);
+                    $('pre.main_source code').each(function(i, e) {hljs.highlightBlock(e)});
                     
                     $('#source_link').attr("href", linkUrl);
+                    
+                    $('.nav-tabs a[href="#main_source"]').text(name + ".c");
+                    
+                    data.matchAll(/TextFormat\("(resources\/(?:[-_a-zA-Z0-9]+\/)*((?:[-_a-zA-Z0-9]+%i|glsl%i\/[-_a-zA-Z0-9]+)\.[fv]s))", GLSL_VERSION\)/g).forEach(function(match, index) {
+                        const shaderUriPattern = match[1];
+                        const shaderName = match[2].replace(/(\/?glsl)?%i/, '').replace(/^\//, ''); // Strip off versions here
+                        const shaderTabId = 'shader_' + (1+index);
+                        
+                        $('.nav-tabs').append(
+                            $('<li><a href="#'+shaderTabId+'">' + shaderName + '</a></li>')
+                        );
+                        
+                        const newCodePanel = $('<code class="glsl"></code>');
+                        $('.tab-content').append(
+                            $('<div id="' + shaderTabId + '"></div>').append(
+                                $('<pre></pre>').append(newCodePanel)
+                            )
+                        );
+                        
+						// Hardcoding glsl version for now
+                        const glslVersion = "330";
+                        
+                        $.get(shaderBaseUrl + shaderUriPattern.replace('%i', glslVersion), function(code) {
+                            newCodePanel.text(code);
+                            newCodePanel.each(function(i, e) {hljs.highlightBlock(e)});
+                        }, 'text');
+                    });
+                    
+
+                    $(".nav-tabs a").click(function(e){
+                        e.preventDefault();
+                        
+                        const paneToActivate = $(this.hash);
+                        $('.tab-content > div.active').removeClass('active');
+                        $('.nav-tabs > li.active').removeClass('active');
+                        
+                        $(this).parent('li').addClass('active');
+                        paneToActivate.addClass('active');
+                    });
+                    
                 }, 'text');
                 
                 // #eximage filling code: canvas sample and image
@@ -129,7 +180,16 @@
         
         <!--<textarea id="output" rows="8"></textarea>-->
         
-        <pre><code class="cpp"></code></pre>
+        <ul class="nav-tabs">
+            <li class="active"><a href="#main_source">Main Source</a></li>
+        </ul>
+        
+        <div class="tab-content">
+            <div id="main_source" class="tab-pane active">
+                <pre class="main_source"><code class="cpp"></code></pre>
+            </div>
+        </div>
+        
         
         <p>raylib example <a id="source_link" href="" target="_blank">source code</a></p>
 

--- a/examples/text/loader.html
+++ b/examples/text/loader.html
@@ -112,7 +112,7 @@
                             )
                         );
                         
-						// Hardcoding glsl version for now
+                        // Hardcoding glsl version for now
                         const glslVersion = "330";
                         
                         $.get(shaderBaseUrl + shaderUriPattern.replace('%i', glslVersion), function(code) {

--- a/examples/text/loader.html
+++ b/examples/text/loader.html
@@ -49,6 +49,16 @@
             .fancybox-wrap fancybox-desktop fancybox-type-iframe fancybox-opened { width: 860px!important;}
             .fancybox-inner { width: 850px!important; }
             .fancybox-iframe { width: 830px!important; }
+            
+            .tab-content > div { display: none; }
+            .tab-content > div.active { display: block; }
+            .tab-content > div pre { margin-top: 0!important; }
+            
+            .nav-tabs { display: block; padding: 0; margin: 10px 0 0 0; list-style: none; font-family: Courier New, Verdana, Arial !important; font-size: small; }
+            .nav-tabs li { position: relative; top: 1px; display: inline-block; margin: 5px 5px 0 5px; padding: 5px; border: 1px solid #b0b0b0; background: white; }
+            .nav-tabs li.active { border-bottom-color: #f0f0f0; background: #f0f0f0; }
+            .nav-tabs li a { text-decoration: none; color: #b0b0b0; }
+            .nav-tabs li.active a { text-decoration: none; color: black; }
         </style>
         
         <script type="text/javascript">
@@ -73,15 +83,56 @@
                 var srcUrl = 'https://raw.githubusercontent.com/raysan5/raylib/master/examples/' + type + '/' + name + '.c';
                 var imgUrl = 'https://raw.githubusercontent.com/raysan5/raylib/master/examples/' + type + '/' + name + '.png';
                 var linkUrl = 'https://github.com/raysan5/raylib/blob/master/examples/' + type + '/' + name + '.c';
+                var shaderBaseUrl = 'https://raw.githubusercontent.com/raysan5/raylib/master/examples/' + type + '/';
 
                 $('#eximage img').attr('src', imgUrl);
 
                 $.get(srcUrl, function(data)
-                { 
-                    $('pre code').text(data);
-                    $('pre code').each(function(i, e) {hljs.highlightBlock(e)});
+                {
+                    $('pre.main_source code').text(data);
+                    $('pre.main_source code').each(function(i, e) {hljs.highlightBlock(e)});
                     
                     $('#source_link').attr("href", linkUrl);
+                    
+                    $('.nav-tabs a[href="#main_source"]').text(name + ".c");
+                    
+                    data.matchAll(/TextFormat\("(resources\/(?:[-_a-zA-Z0-9]+\/)*((?:[-_a-zA-Z0-9]+%i|glsl%i\/[-_a-zA-Z0-9]+)\.[fv]s))", GLSL_VERSION\)/g).forEach(function(match, index) {
+                        const shaderUriPattern = match[1];
+                        const shaderName = match[2].replace(/(\/?glsl)?%i/, '').replace(/^\//, ''); // Strip off versions here
+                        const shaderTabId = 'shader_' + (1+index);
+                        
+                        $('.nav-tabs').append(
+                            $('<li><a href="#'+shaderTabId+'">' + shaderName + '</a></li>')
+                        );
+                        
+                        const newCodePanel = $('<code class="glsl"></code>');
+                        $('.tab-content').append(
+                            $('<div id="' + shaderTabId + '"></div>').append(
+                                $('<pre></pre>').append(newCodePanel)
+                            )
+                        );
+                        
+						// Hardcoding glsl version for now
+                        const glslVersion = "330";
+                        
+                        $.get(shaderBaseUrl + shaderUriPattern.replace('%i', glslVersion), function(code) {
+                            newCodePanel.text(code);
+                            newCodePanel.each(function(i, e) {hljs.highlightBlock(e)});
+                        }, 'text');
+                    });
+                    
+
+                    $(".nav-tabs a").click(function(e){
+                        e.preventDefault();
+                        
+                        const paneToActivate = $(this.hash);
+                        $('.tab-content > div.active').removeClass('active');
+                        $('.nav-tabs > li.active').removeClass('active');
+                        
+                        $(this).parent('li').addClass('active');
+                        paneToActivate.addClass('active');
+                    });
+                    
                 }, 'text');
                 
                 // Quick hack for some examples not working on web
@@ -137,7 +188,15 @@
         
         <!--<textarea id="output" rows="8"></textarea>-->
         
-        <pre><code class="cpp"></code></pre>
+        <ul class="nav-tabs">
+            <li class="active"><a href="#main_source">Main Source</a></li>
+        </ul>
+        
+        <div class="tab-content">
+            <div id="main_source" class="tab-pane active">
+                <pre class="main_source"><code class="cpp"></code></pre>
+            </div>
+        </div>
         
         <p>raylib example <a id="source_link" href="" target="_blank">source code</a></p>
 


### PR DESCRIPTION
When viewing certain examples, such as shaders, seeing the `.c` source code is all well and good, but the meat of it is in the shader files themselves.

This PR automatically scans the `.c` code for references to example shader files, loads them and displays a tab view for flipping between the C source and the shaders source(s). The shader source(s) are also formatted with `highlight.js`, using `glsl` formatting.

<img width="825" height="585" alt="image" src="https://github.com/user-attachments/assets/7a2c9ba1-5816-4a75-a2ab-0eb266f4b322" />

The CSS and JS are minimal, no additional dependencies added.

Currently it only loads the GLSL 330 versions; this could be modified in the future to allow the user to choose the version.