### PR TITLE
404.html : Add raylib.com domain to image logo, css and favicon to fix a file not found error

### DIFF
--- a/404.html
+++ b/404.html
@@ -7,10 +7,10 @@
         <style>
             @font-face {
                 font-family: 'grixel_acme_7_wide_xtnd';
-                src: url('./common/font/acme_7_wide_xtnd.eot');
-                src: url('./common/font/acme_7_wide_xtnd.eot?#iefix') format('embedded-opentype'),
-                    url('./common/font/acme_7_wide_xtnd.woff') format('woff'),
-                    url('./common/font/acme_7_wide_xtnd.ttf') format('truetype');
+                src: url('https://www.raylib.com/common/font/acme_7_wide_xtnd.eot');
+                src: url('https://www.raylib.com/common/font/acme_7_wide_xtnd.eot?#iefix') format('embedded-opentype'),
+                    url('https://www.raylib.com/common/font/acme_7_wide_xtnd.woff') format('woff'),
+                    url('https://www.raylib.com/common/font/acme_7_wide_xtnd.ttf') format('truetype');
                 font-weight: normal;
                 font-style: normal;
                 font-size-adjust: 0.49;

--- a/404.html
+++ b/404.html
@@ -74,7 +74,7 @@
     <body>
         <div class="container">
             <a href="https://www.raylib.com">
-                <img src="./common/img/raylib_logo.png" alt="raylib logo">
+                <img src="https://www.raylib.com/common/img/raylib_logo.png" alt="raylib logo">
             </a>
             <div class="content_404">
                 <h1>page not found</h1>

--- a/404.html
+++ b/404.html
@@ -3,7 +3,7 @@
     <head>
         <meta charset="utf-8">
         <title>raylib | page not found... :(</title>
-        <link rel="shortcut icon" href="favicon.ico" />
+        <link rel="shortcut icon" href="https://www.raylib.com/favicon.ico" />
         <style>
             @font-face {
                 font-family: 'grixel_acme_7_wide_xtnd';


### PR DESCRIPTION
In case the page is loaded outside of the root folder the raylib logo can't be found. This change fixes this small issue.

Replacate:
https://www.raylib.com/examples.h/tmld

Screenshot:
<img width="639" height="395" alt="image" src="https://github.com/user-attachments/assets/adba5a0d-8646-4dda-b5ad-01c4d903792b" />

How will look after this PR:
<img width="596" height="538" alt="image" src="https://github.com/user-attachments/assets/364256ad-f447-4005-a860-c2e118909f9a" />
