### PR TITLE
[examples] Added lazy load to images

### DIFF
--- a/common/examples.js
+++ b/common/examples.js
@@ -237,7 +237,7 @@ $(document).ready(function() {
         const exampleDiv = $(
             `<div class="mix f${module}">` +
                 `<a class="fancybox fancybox.iframe" href="${exampleLoaderURL}" title="${description}">` +
-                `<img width="400" height="225" src="${previewImageURL}"><div class="extext"><p>${description}</p></div></a>` +
+                `<img width="400" height="225" loading="lazy" src="${previewImageURL}"><div class="extext"><p>${description}</p></div></a>` +
                 `<div id="difficulty_level">${difficulty}</div>` +
             '</div>')[0];
 


### PR DESCRIPTION
The preview images are starting to take awhile to load now. This small change will only load the images that are visible on screen, so the user must scroll/filter/search and view examples before the images will load, making the page finish quicker

Before: 190 requests, 6.0s load
<img width="689" height="162" alt="image" src="https://github.com/user-attachments/assets/0b5b530d-3f69-4bf1-a208-b33318a3fe40" />

After: 30 requests, 0.3s load (20x improvement)
<img width="689" height="162" alt="image" src="https://github.com/user-attachments/assets/0d028c57-8feb-49c8-8c26-f4981f335a6f" />
