### PR TITLE
[cheatsheet/raylib_raymath.c] Correcting the description for the Clamp function from raymath

### DIFF
--- a/cheatsheet/raylib_raymath.c
+++ b/cheatsheet/raylib_raymath.c
@@ -1,6 +1,8 @@
 
     // Utils math
-    float Clamp(float value, float min, float max)                              // Function specifiers definition Defines and Macros Get float vector for Matrix Get float vector for Vector3 Types and Structures Definition Vector2 type Vector3 type Vector4 type Quaternion type Matrix type (OpenGL style 4x4 - right handed, column major) NOTE: Helper types to be used instead of array return types for *ToFloat functions Clamp float value
+    // Function specifiers definition Defines and Macros Get float vector for Matrix Get float vector for Vector3 Types and Structures Definition Vector2 type Vector3 type Vector4 type Quaternion type Matrix type (OpenGL style 4x4 - right handed, column major)
+    // NOTE: Helper types to be used instead of array return types for *ToFloat functions
+    float Clamp(float value, float min, float max)                              // Clamp float value
     float Lerp(float start, float end, float amount)                            // Calculate linear interpolation between two floats
     float Normalize(float value, float start, float end)                        // Normalize input value within input range
     float Remap(float value, float inputStart, float inputEnd, float outputStart, float outputEnd) // Remap input value within input range to output range


### PR DESCRIPTION
The description in the raylib_raymath.c for the Clamp function from raymath seems to include notes from other parts of the documentation. Those have been put above everything since I don't know were they are from