### PR TITLE
Update paths in 404.html for working fonts, favicon and images

### DIFF
--- a/404.html
+++ b/404.html
@@ -3,14 +3,14 @@
     <head>
         <meta charset="utf-8">
         <title>raylib | page not found... :(</title>
-        <link rel="shortcut icon" href="favicon.ico" />
+        <link rel="shortcut icon" href="/favicon.ico" />
         <style>
             @font-face {
                 font-family: 'grixel_acme_7_wide_xtnd';
-                src: url('./common/font/acme_7_wide_xtnd.eot');
-                src: url('./common/font/acme_7_wide_xtnd.eot?#iefix') format('embedded-opentype'),
-                    url('./common/font/acme_7_wide_xtnd.woff') format('woff'),
-                    url('./common/font/acme_7_wide_xtnd.ttf') format('truetype');
+                src: url('/common/font/acme_7_wide_xtnd.eot');
+                src: url('/common/font/acme_7_wide_xtnd.eot?#iefix') format('embedded-opentype'),
+                    url('/common/font/acme_7_wide_xtnd.woff') format('woff'),
+                    url('/common/font/acme_7_wide_xtnd.ttf') format('truetype');
                 font-weight: normal;
                 font-style: normal;
                 font-size-adjust: 0.49;
@@ -74,7 +74,7 @@
     <body>
         <div class="container">
             <a href="https://www.raylib.com">
-                <img src="./common/img/raylib_logo.png" alt="raylib logo">
+                <img src="/common/img/raylib_logo.png" alt="raylib logo">
             </a>
             <div class="content_404">
                 <h1>page not found</h1>


### PR DESCRIPTION
There was an error where any 404 page would try to open favicon, fonts and images from their url instead of the website root.

Example:
with this invalid page: https://www.raylib.com/commn/img/
This currently result in favicon being loaded from https://www.raylib.com/commn/img/favicon.ico
And same for the logo: https://www.raylib.com/commn/img/common/img/raylib_logo.png

This commit hopefully fixes theses errors.

I did not fully verify, but when loading from a web server the page will attempt to load from the website root, which is the correct expected behavior